### PR TITLE
Oldest safe is 0.3.0

### DIFF
--- a/docs/version.json
+++ b/docs/version.json
@@ -1,4 +1,4 @@
 {
   "latest": "0.3.0",
-  "oldest_safe": "0.0.1"
+  "oldest_safe": "0.3.0"
 }


### PR DESCRIPTION
Since 0.3.0 fixes a "potential sandbox escape vulnerability", I will be changing the oldest safe to 0.3.0.