### PR TITLE
Consistent UI in desktop app download page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,782 +1,789 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TurboWarp Desktop</title>
-    <meta name="description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop.">
-    <meta name="theme-color" content="#ff4c4c">
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="TurboWarp Desktop" />
-    <meta property="og:description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop." />
-    <meta property="og:url" content="https://desktop.turbowarp.org/" />
-    <meta property="og:image" content="https://desktop.turbowarp.org/screenshot-light.png" />
-    <meta property="og:image:width" content="1280" />
-    <meta property="og:image:height" content="800" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <style>
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-        margin: 0;
-        padding: 0;
-        font-size: 16px;
-        background-color: white;
-        color: black;
-      }
-      a {
-        color: #25d;
-        text-decoration: none;
-      }
-      a:hover {
-        text-decoration: underline;
-      }
-      a:active {
-        color: red;
-      }
-      img {
-        display: block;
-      }
-      section {
-        display: flex;
-        justify-content: center;
-        width: 100%;
-        padding-right: 8px;
-        padding-left: 8px;
-      }
-      body:not([loaded]) section:not(.visible-loading) {
-        visibility: hidden;
-      }
-      body:not([loaded]) .transparent-loading {
-        visibility: hidden;
-      }
-      section > div {
-        width: 100%;
-        max-width: 700px;
-      }
-      code, .code {
-        font-family: monospace;
-        font-size: 1rem;
-        padding: 3px;
-        background: #e6e6e6;
-        border-radius: 3px;
-      }
-      hr {
-        width: 100%;
-        height: 0;
-        border: none;
-        border-top: 1px dashed #aaa;
-      }
-
-      .header {
-        padding-top: 32px;
-        padding-bottom: 32px;
-        color: black;
-        background-color: #ff4c4c;
-        text-align: center;
-      }
-      .header-title {
-        margin: 32px 0;
-        font-size: 48px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: normal;
-      }
-      .header-title svg {
-        margin: 0 20px 0 0;
-        filter: drop-shadow(0 1px 8px rgba(0, 0, 0, 0.25));
-        width: 96px;
-        height: 96px;
-        min-width: 96px;
-        min-height: 96px;
-      }
-      @media (max-width: 400px) {
-        .header-title {
-          flex-direction: column;
-          margin-top: 0;
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>TurboWarp Desktop</title>
+      <meta name="description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop.">
+      <meta name="theme-color" content="#ff4c4c">
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content="TurboWarp Desktop" />
+      <meta property="og:description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop." />
+      <meta property="og:url" content="https://desktop.turbowarp.org/" />
+      <meta property="og:image" content="https://desktop.turbowarp.org/screenshot-light.png" />
+      <meta property="og:image:width" content="1280" />
+      <meta property="og:image:height" content="800" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <style>
+        * {
+          box-sizing: border-box;
         }
-        .header-title svg {
-          margin: 0 0 20px 0;
-        }
-      }
-      .header-subtitles > * {
-        margin-left: auto;
-        margin-right: auto;
-        max-width: 700px;
-      }
-      .header a {
-        color: inherit;
-        text-decoration: underline;
-      }
 
-      .changelog {
-        display: none;
-        margin-bottom: 32px;
-      }
-      [changelog="true"] .changelog {
-        display: flex;
-      }
-      .changelog li {
-        margin-top: 4px;
-      }
-
-      .select-os {
-        box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
-        background: white;
-        position: relative;
-        z-index: 99;
-        margin-bottom: 32px;
-      }
-      .select-os-inner {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-wrap: wrap;
-        white-space: nowrap;
-      }
-      .select-os-buttons {
-        margin-top: 16px;
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: center;
-      }
-      .select-os-buttons button {
-        margin: 0 16px 16px 0;
-        border: 0;
-        cursor: pointer;
-        color: black;
-        font-size: .8rem;
-        font-weight: bold;
-        font-family: inherit;
-        border-radius: 26px;
-        background-color: rgba(0, 0, 0, 0.2);
-        padding: 8px 18px;
-        display: flex;
-        align-items: center;
-      }
-      .select-os-buttons button:last-child {
-        margin-right: 0;
-      }
-      .select-os-buttons button:hover {
-        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
-      }
-      .select-os-buttons button:active {
-        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
-      }
-      .os-button-icon {
-        margin-right: 5px;
-        width: 24px;
-        height: 24px;
-      }
-      [os="windows"] .os-button-windows,
-      [os="mac"] .os-button-mac,
-      [os="linux"] .os-button-linux,
-      [os="chrome"] .os-button-chrome {
-        background-color: #ff4c4c;
-        color: black;
-      }
-
-      .os {
-        margin-bottom: 32px;
-      }
-      body:not([os="windows"]) .os-windows,
-      body:not([os="mac"]) .os-mac,
-      body:not([os="linux"]) .os-linux,
-      body:not([os="chrome"]) .os-chrome {
-        display: none;
-      }
-
-      .command::before {
-        content: "$ ";
-      }
-
-      .download-button-outer {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-      }
-      .download-button-inner {
-        display: flex;
-        align-items: center;
-        background-image: linear-gradient(#ff9494, #ff4c4c);
-        color: black !important;
-        text-decoration: none !important;
-        padding: 12px 18px;
-        font-weight: bold;
-        border-radius: 5px;
-      }
-      .download-button-inner:hover {
-        background-image: linear-gradient(#ff7979, #ff4c4c);
-      }
-      .download-button-inner:active {
-        box-shadow: 0 0 8px rgba(0, 0, 0, 0.6) inset;
-        background-image: linear-gradient(#ff5d5d, #ff4c4c);
-      }
-      .download-icon {
-        /* Icon from https://fontawesome.com/v5.15/icons/download?style=solid */
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="black" d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"></path></svg>');
-        margin-right: 10px;
-        width: 16px;
-        height: 16px;
-        min-width: 16px;
-        min-height: 16px;
-      }
-      .install-help {
-        margin: 32px 0 0 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-      }
-      .install-help p {
-        margin: 0 0 16px 0;
-      }
-
-      .icon {
-        background-color: #ff4c4c;
-        color: black;
-        width: 32px;
-        height: 32px;
-        margin: 0 12px;
-        border-radius: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .icon svg {
-        width: 20px;
-        height: 20px;
-      }
-      .links {
-        margin-bottom: 32px;
-      }
-      .links-inner {
-        columns: 2;
-        column-gap: 0;
-      }
-      @media (max-width: 550px) {
-        .links-inner {
-          columns: 1;
-        }
-      }
-      .link {
-        color: inherit;
-        display: flex;
-        align-items: center;
-        padding: 15px 0;
-        transition: .2s background-color;
-      }
-      .link:hover {
-        background-color: #eee;
-      }
-
-      .picture-container {
-        flex-direction: column;
-        text-align: center;
-        align-items: center;
-      }
-      .picture {
-        width: 100%;
-        height: 100%;
-        max-width: 1280px;
-      }
-      .picture-dark {
-        display: none;
-      }
-      .picture-caption {
-        padding-top: 4px;
-      }
-
-      .pwa-install {
-        width: 100%;
-        height: 100%;
-        max-width: 620px;
-      }
-
-      :focus-visible {
-        outline: 2px solid black;
-      }
-
-      @media (prefers-color-scheme: dark) {
         body {
-          background: #171717;
-          color: #eee;
+          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+          margin: 0;
+          padding: 0;
+          font-size: 16px;
+          background-color: white;
+          color: black;
         }
         a {
-          color: #4af;
+          color: #25d;
+          text-decoration: none;
         }
-        code, .code {
-          background-color: #222;
+        a:hover {
+          text-decoration: underline;
         }
-        a code {
-          color: #4af;
+        a:active {
+          color: red;
         }
-        hr {
-          border-color: #333;
-        }
-        .select-os {
-          box-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
-          background: #1a1a1a;
-        }
-        .select-os-inner button {
-          color: white;
-          background-color: rgba(255, 255, 255, 0.2);
-        }
-        .link:hover {
-          background-color: #333;
-        }
-        .picture-dark {
+        img {
           display: block;
         }
-        .picture-light {
+        section {
+          display: flex;
+          justify-content: center;
+          width: 100%;
+          padding-right: 8px;
+          padding-left: 8px;
+        }
+        body:not([loaded]) section:not(.visible-loading) {
+          visibility: hidden;
+        }
+        body:not([loaded]) .transparent-loading {
+          visibility: hidden;
+        }
+        section > div {
+          width: 100%;
+          max-width: 700px;
+        }
+        code, .code {
+          font-family: monospace;
+          font-size: 1rem;
+          padding: 3px;
+          background: #e6e6e6;
+          border-radius: 3px;
+        }
+        hr {
+          width: 100%;
+          height: 0;
+          border: none;
+          border-top: 1px dashed #aaa;
+        }
+
+        .header {
+          padding-top: 32px;
+          padding-bottom: 32px;
+          color: black;
+          background-color: #ff4c4c;
+          text-align: center;
+        }
+        .header-title {
+          margin: 32px 0;
+          font-size: 48px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: normal;
+        }
+        .header-title svg {
+          margin: 0 20px 0 0;
+          filter: drop-shadow(0 1px 8px rgba(0, 0, 0, 0.25));
+          width: 96px;
+          height: 96px;
+          min-width: 96px;
+          min-height: 96px;
+        }
+        @media (max-width: 400px) {
+          .header-title {
+            flex-direction: column;
+            margin-top: 0;
+          }
+          .header-title svg {
+            margin: 0 0 20px 0;
+          }
+        }
+        .header-subtitles > * {
+          margin-left: auto;
+          margin-right: auto;
+          max-width: 700px;
+        }
+        .header a {
+          color: inherit;
+          text-decoration: underline;
+        }
+
+        .changelog {
+          display: none;
+          margin-bottom: 32px;
+        }
+        [changelog="true"] .changelog {
+          display: flex;
+        }
+        .changelog li {
+          margin-top: 4px;
+        }
+
+        .select-os {
+          box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+          background: white;
+          position: relative;
+          z-index: 99;
+          margin-bottom: 32px;
+        }
+        .select-os-inner {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-wrap: wrap;
+          white-space: nowrap;
+        }
+        .select-os-buttons {
+          margin-top: 16px;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+          justify-content: center;
+        }
+        .select-os-buttons button {
+          margin: 0 16px 16px 0;
+          border: 0;
+          cursor: pointer;
+          color: black;
+          font-size: .8rem;
+          font-weight: bold;
+          font-family: inherit;
+          border-radius: 26px;
+          background-color: rgba(0, 0, 0, 0.2);
+          padding: 8px 18px;
+          display: flex;
+          align-items: center;
+        }
+        .select-os-buttons button:last-child {
+          margin-right: 0;
+        }
+        .select-os-buttons button:hover {
+          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+        }
+        .select-os-buttons button:active {
+          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
+        }
+        .os-button-icon {
+          margin-right: 5px;
+          width: 24px;
+          height: 24px;
+        }
+        [os="windows"] .os-button-windows,
+        [os="mac"] .os-button-mac,
+        [os="linux"] .os-button-linux,
+        [os="chrome"] .os-button-chrome {
+          background-color: #ff4c4c;
+          color: black;
+        }
+
+        .os {
+          margin-bottom: 32px;
+        }
+        body:not([os="windows"]) .os-windows,
+        body:not([os="mac"]) .os-mac,
+        body:not([os="linux"]) .os-linux,
+        body:not([os="chrome"]) .os-chrome {
           display: none;
         }
+
+        .command::before {
+          content: "$ ";
+        }
+
+        .download-button-outer {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+        }
+        .download-button-inner {
+          display: flex;
+          align-items: center;
+          background-color: #ff4c4c;
+          color: black !important;
+          text-decoration: none !important;
+          padding: 12px 18px;
+          font-weight: bold;
+          border-radius: 5px;
+        }
+        .download-button-inner:hover {
+          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+        }
+        .download-button-inner:active {
+          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
+        }
+        .download-icon {
+          /* Icon from https://fontawesome.com/v5.15/icons/download?style=solid */
+          background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="black" d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"></path></svg>');
+          margin-right: 10px;
+          width: 16px;
+          height: 16px;
+          min-width: 16px;
+          min-height: 16px;
+        }
+        .install-help {
+          margin: 32px 0 0 0;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+        }
+        .install-help p {
+          margin: 0 0 16px 0;
+        }
+
+        .icon {
+          background-color: #ff4c4c;
+          color: black;
+          width: 32px;
+          height: 32px;
+          margin: 0 12px;
+          border-radius: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .icon svg {
+          width: 20px;
+          height: 20px;
+        }
+        .links {
+          margin-bottom: 32px;
+        }
+        .links-inner {
+          columns: 2;
+          column-gap: 0;
+        }
+        @media (max-width: 550px) {
+          .links-inner {
+            columns: 1;
+          }
+        }
+        .link {
+          color: inherit;
+          display: flex;
+          align-items: center;
+          padding: 15px 0;
+          transition: .2s background-color;
+        }
+        .link:hover {
+          background-color: #eee;
+        }
+
+        .picture-container {
+          flex-direction: column;
+          text-align: center;
+          align-items: center;
+        }
+        .picture {
+          width: 100%;
+          height: 100%;
+          max-width: 1280px;
+        }
+        .picture-dark {
+          display: none;
+        }
+        .picture-caption {
+          padding-top: 4px;
+        }
+
+        .pwa-install {
+          width: 100%;
+          height: 100%;
+          max-width: 620px;
+        }
+
         :focus-visible {
-          outline: 2px solid white;
-        }
-      }
-    </style>
-  </head>
-
-  <!--
-    Some icons are from Font Awesome https://fontawesome.com/
-    For license information, visit https://creativecommons.org/licenses/by/4.0/
-    Icons have been minified by hand.
-  -->
-
-  <body os="">
-    <section class="header visible-loading">
-      <div>
-        <h1 class="header-title">
-          <svg aria-hidden="true" viewBox="0 0 1024 1024">
-            <path d="m64 174.86735v641.13265c0 35.34622 28.653776 64 64 64h113.30332c9.32935 0 18.19416 4.07135 24.27337 11.14807l67.26992 78.30776c12.15843 14.15343 29.88806 22.29614 48.54676 22.29614h261.21326c18.6587 0 36.38832-8.14271 48.54676-22.29614l67.26992-78.30776c6.07921-7.07672 14.94402-11.14807 24.27337-11.14807h113.30332c35.34622 0 64-28.65378 64-64v-654.84694c0-35.34622-28.65378-64-64-64-0.38091 0-0.76182 0.0034-1.14268 0.0102l-767.99999 13.71429c-34.89522 0.62313-62.85733 29.08902-62.85733 63.9898z" fill="#cc3c3c" fill-rule="evenodd"/>
-            <path d="m64 96v672c0 35.34622 28.653776 64 64 64h128.17394c9.97413 0 19.37789 4.65076 25.43168 12.5776l51.18313 67.01917c12.1076 15.85368 30.9151 25.1552 50.86336 25.1552h256.69578c19.94826 0 38.75576-9.30152 50.86336-25.1552l51.18312-67.01917c6.0538-7.92684 15.45756-12.5776 25.43169-12.5776h128.17394c35.34622 0 64-28.65378 64-64v-672c0-35.346224-28.65378-64-64-64h-768c-35.346224 0-64 28.653776-64 64z" fill="#ff4c4c" fill-rule="evenodd"/>
-            <path d="m96 96v672c0 17.67311 14.32689 32 32 32h128.17394c19.94827 0 38.75577 9.30152 50.86337 25.1552l51.18312 67.01917c6.0538 7.92684 15.45755 12.5776 25.43168 12.5776h256.69578c9.97413 0 19.37788-4.65076 25.43168-12.5776l51.18312-67.01917c12.1076-15.85368 30.9151-25.1552 50.86337-25.1552h128.17394c17.67311 0 32-14.32689 32-32v-672c0-17.673112-14.32689-32-32-32h-768c-17.67311 0-32 14.326888-32 32zm-32 0c0-35.346224 28.653776-64 64-64h768c35.34622 0 64 28.653776 64 64v672c0 35.34622-28.65378 64-64 64h-128.17394c-9.97413 0-19.37789 4.65076-25.43169 12.5776l-51.18312 67.01917c-12.1076 15.85368-30.9151 25.1552-50.86336 25.1552h-256.69578c-19.94826 0-38.75576-9.30152-50.86336-25.1552l-51.18313-67.01917c-6.05379-7.92684-15.45755-12.5776-25.43168-12.5776h-128.17394c-35.346224 0-64-28.65378-64-64z" fill="#fff" fill-opacity=".2"/>
-            <g transform="matrix(4.1943736,0,0,4.1943736,229.13567,171.21359)" fill="none" stroke="#fff" stroke-width="56.4093">
-             <path d="m108.34581 31.577677c-0.79395 3.473563-1.38942 7.244861-1.7864 11.313892-0.0992 1.091691 0 2.481117 0.29773 4.168276 0.29773 1.984893 0.4466 3.374319 0.4466 4.168276 0 2.580361-1.68716 3.870542-5.06147 3.870542-2.18339 0-3.622435-0.64509-4.317148-1.935271-0.09925-2.183383-0.04962-5.160723 0.14887-8.93202 0.198487-4.46601 0.29773-7.44335 0.29773-8.93202-0.09924 0-0.248107-0.09924-0.4466-0.297734-9.229753 0.396979-17.91366 0.992447-26.05172 1.786404-0.198493 1.290181-0.198493 2.878095 0 4.763744l0.59546 5.359212c-0.396973 3.076585-0.59546 7.64184-0.59546 13.695765 0.297733 2.580361 0.4466 13.646143 0.4466 33.197344v10.867303c0 1.68716 0.24811 2.8781 0.74433 3.57281h9.22976c3.771293-0.49623 5.65694 1.09169 5.65694 4.76374 0 2.18339-1.042067 3.72168-3.1262 4.61488-1.290187 0.49623-3.572817 0.59547-6.84789 0.29774-1.984893-0.19849-4.317143-0.24812-6.99675-0.14887-3.672053 0.49622-8.138063 0.8932-13.39803 1.19093-5.359207 0.29774-8.634279-0.44659-9.825218-2.233-0.793957-1.19093-0.793957-2.43149 0-3.72168 1.389425-2.18338 5.011855-3.27507 10.867288-3.27507 3.076587 0 4.61488-0.84358 4.61488-2.53074 0-0.8932-0.04962-1.73678-0.14887-2.53074 0-2.48113 0.04962-4.66452 0.14887-6.550163 0.297733-5.359213 0.297733-12.901808 0-22.627784-0.39698-14.092743-0.248113-26.746439 0.4466-37.961086l-0.4466-0.446601c-3.076587 0.198489-8.832777 0.148867-17.268572-0.148867-0.396979 0-3.423941 0.198489-9.080887 0.595468 1.389425 9.527488 2.183383 16.325748 2.381872 20.394779l-0.297734 4.01941c-0.09924 1.48867-1.339803 2.233005-3.721676 2.233005-1.885649 0-3.473563-3.572808-4.763744-10.718425-0.595468-4.267521-1.190936-8.584664-1.786404-12.951429 0-0.694713-0.347356-1.885649-1.042069-3.572808-0.595468-1.786404-1.908676-4.750966-1.908676-5.644168 0-3.141175 2.901123-2.39465 6.67242-2.990118 0.297734 0 0.793957 0.04962 1.48867 0.148867 0.694713 0.09924 1.190936 0.148867 1.48867 0.148867h36.91902c9.130507-0.396979 17.96328-1.190936 26.49832-2.381872 0.595473-0.297734 1.488678-0.595468 2.679608-0.893202 2.08414-0.19849 3.87054 0.297733 5.35921 1.48867 1.48867 1.091691 1.9849 2.679606 1.48867 4.763744z" fill="none" stroke="#fff" stroke-width="56.4093"/>
-            </g>
-            <g transform="matrix(3.852509,0,0,3.852509,257.89982,219.83848)" fill="none" stroke="#ff4c4c" stroke-width="30.7075">
-             <path d="m110.38498 21.776581q-1.29661 5.672702-1.94492 12.317866-0.16208 1.782849 0.32415 4.538161 0.48623 3.241544 0.48623 4.538161 0 4.214007-5.51062 4.214007-3.5657 0-4.700239-2.107004-0.16208-3.565698 0.16208-9.72463 0.32415-7.293474 0.32415-9.724631-0.16207 0-0.48623-0.324155-15.073176 0.648309-28.3635 1.944927-0.324161 2.107003 0 5.186469l0.6483 5.834779q-0.6483 5.024392-0.6483 14.911102 0.48623 4.214006 0.48623 36.143214v11.831633q0 2.75531 0.81038 3.88985h10.048792q6.158927-0.81039 6.158927 5.18647 0 3.5657-3.403614 5.0244-2.107013 0.81039-7.455559 0.32416-3.241543-0.32416-7.617628-0.16208-5.996857 0.81038-14.586946 1.29661-8.75216 0.48624-10.69709-2.43115-1.296617-1.94493 0-4.05194 2.26908-3.56569 11.831631-3.56569 5.024396 0 5.024396-2.75532 0-1.45869-0.162081-2.75531 0-4.051935 0.162081-7.131398 0.48623-8.75217 0-24.635731-0.648311-23.014961 0.48623-41.329683l-0.48623-0.486231q-5.024396 0.324154-18.800953-0.162077-0.648309 0-9.886708 0.648308 2.26908 15.55941 2.593235 22.204574 0 0-0.324155 4.376085-0.162077 2.431158-4.05193 2.431158-3.079467 0-5.18647-11.669558-0.972463-6.969319-1.944926-14.100715 0-1.13454-1.134541-3.889852-0.972463-2.91739-0.972463-4.376084 0-4.05193 6.158933-5.024393 0.486232 0 1.620772 0.162077 1.13454 0.162078 1.620772 0.162078h16.856029q23.339116 0 23.339116 0 14.911096-0.648309 28.849729-2.593235 0.97247-0.486232 2.91739-0.972463 3.40363-0.324156 5.83478 1.620771 2.43116 1.782849 1.62077 5.18647z" fill="none" stroke="#ff4c4c" stroke-width="30.7075"/>
-            </g>
-            <g transform="matrix(4.1943736,0,0,4.1943736,228.25358,197.35677)" fill="#fff">
-             <path d="m108.34581 25.3789q-1.19093 5.210345-1.7864 11.313892-0.14887 1.637537 0.29773 4.168276 0.4466 2.97734 0.4466 4.168276 0 3.870542-5.06147 3.870542-3.275078 0-4.317148-1.935271-0.14887-3.275074 0.14887-8.93202 0.29773-6.699015 0.29773-8.93202-0.14886 0-0.4466-0.297734-13.84463 0.595468-26.05172 1.786404-0.29774 1.935271 0 4.763744l0.59546 5.359212q-0.59546 4.614877-0.59546 13.695765 0.4466 3.870542 0.4466 33.197344v10.86729q0 2.53074 0.74433 3.57281h9.22976q5.65694-0.74434 5.65694 4.76374 0 3.27508-3.1262 4.61488-1.93528 0.74434-6.84789 0.29774-2.97734-0.29774-6.99675-0.14887-5.50808 0.74433-13.39803 1.19093-8.03881 0.44661-9.825218-2.233-1.190936-1.7864 0-3.72168 2.084138-3.27507 10.867288-3.27507 4.61488 0 4.61488-2.53074 0-1.3398-0.14887-2.53074 0-3.72168 0.14887-6.55015 0.4466-8.03882 0-22.627784-0.59547-21.139115 0.4466-37.961086l-0.4466-0.446601q-4.61488 0.297734-17.268572-0.148867-0.595468 0-9.080887 0.595468 2.084138 14.291232 2.381872 20.394779 0 0-0.297734 4.01941-0.148867 2.233005-3.721676 2.233005-2.828473 0-4.763744-10.718425-0.893202-6.401281-1.786404-12.951429 0-1.042069-1.042069-3.572808-0.893202-2.679606-0.893202-4.019409 0-3.721675 5.656946-4.614877 0.446601 0 1.48867 0.148867t1.48867 0.148867h15.48217q21.43685 0 21.43685 0 13.69576-0.595468 26.49832-2.381872 0.89321-0.446601 2.679608-0.893202 3.12621-0.297735 5.35921 1.48867 2.23301 1.637537 1.48867 4.763744z" fill="#fff"/>
-            </g>
-          </svg>
-          <div>TurboWarp Desktop</div>
-        </h1>
-        <div class="header-subtitles">
-          <noscript><p>This page requires JavaScript.</p></noscript>
-          <p data-l10n="header.subtitle" class="transparent-loading">Use <a href="https://turbowarp.org" data-notranslate>TurboWarp</a>, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop. It even works when you're offline.</p>
-          <p class="transparent-loading"><i data-l10n="header.affiliation">TurboWarp is not affiliated with Scratch, the Scratch Team, or the Scratch Foundation.</i></p>
-        </div>
-      </div>
-    </section>
-
-    <section class="select-os" id="select-os">
-      <div class="select-os-inner">
-        <div class="select-os-buttons">
-          <button class="os-button-windows">
-            <!-- Icon from https://fontawesome.com/icons/windows?style=brands -->
-            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"></path></svg>
-            <div>
-              Windows
-            </div>
-          </button>
-          <button class="os-button-mac">
-            <!-- Icon from https://fontawesome.com/icons/apple?style=brands -->
-            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"></path></svg>
-            <div>
-              macOS
-            </div>
-          </button>
-          <button class="os-button-linux">
-            <!-- Icon from https://fontawesome.com/icons/linux?style=brands -->
-            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-6.5 5.8-11.4 14.7-16.6 20.2-4.2 4.3-10.3 5.9-17 8.3s-14 6-18.5 14.5c-2.1 3.9-2.8 8.1-2.8 12.4 0 3.9.6 7.9 1.2 11.8 1.2 8.1 2.5 15.7.8 20.8-5.2 14.4-5.9 24.4-2.2 31.7 3.8 7.3 11.4 10.5 20.1 12.3 17.3 3.6 40.8 2.7 59.3 12.5 19.8 10.4 39.9 14.1 55.9 10.4 11.6-2.6 21.1-9.6 25.9-20.2 12.5-.1 26.3-5.4 48.3-6.6 14.9-1.2 33.6 5.3 55.1 4.1.6 2.3 1.4 4.6 2.5 6.7v.1c8.3 16.7 23.8 24.3 40.3 23 16.6-1.3 34.1-11 48.3-27.9 13.6-16.4 36-23.2 50.9-32.2 7.4-4.5 13.4-10.1 13.9-18.3.4-8.2-4.4-17.3-15.5-29.7zM223.7 87.3c9.8-22.2 34.2-21.8 44-.4 6.5 14.2 3.6 30.9-4.3 40.4-1.6-.8-5.9-2.6-12.6-4.9 1.1-1.2 3.1-2.7 3.9-4.6 4.8-11.8-.2-27-9.1-27.3-7.3-.5-13.9 10.8-11.8 23-4.1-2-9.4-3.5-13-4.4-1-6.9-.3-14.6 2.9-21.8zM183 75.8c10.1 0 20.8 14.2 19.1 33.5-3.5 1-7.1 2.5-10.2 4.6 1.2-8.9-3.3-20.1-9.6-19.6-8.4.7-9.8 21.2-1.8 28.1 1 .8 1.9-.2-5.9 5.5-15.6-14.6-10.5-52.1 8.4-52.1zm-13.6 60.7c6.2-4.6 13.6-10 14.1-10.5 4.7-4.4 13.5-14.2 27.9-14.2 7.1 0 15.6 2.3 25.9 8.9 6.3 4.1 11.3 4.4 22.6 9.3 8.4 3.5 13.7 9.7 10.5 18.2-2.6 7.1-11 14.4-22.7 18.1-11.1 3.6-19.8 16-38.2 14.9-3.9-.2-7-1-9.6-2.1-8-3.5-12.2-10.4-20-15-8.6-4.8-13.2-10.4-14.7-15.3-1.4-4.9 0-9 4.2-12.3zm3.3 334c-2.7 35.1-43.9 34.4-75.3 18-29.9-15.8-68.6-6.5-76.5-21.9-2.4-4.7-2.4-12.7 2.6-26.4v-.2c2.4-7.6.6-16-.6-23.9-1.2-7.8-1.8-15 .9-20 3.5-6.7 8.5-9.1 14.8-11.3 10.3-3.7 11.8-3.4 19.6-9.9 5.5-5.7 9.5-12.9 14.3-18 5.1-5.5 10-8.1 17.7-6.9 8.1 1.2 15.1 6.8 21.9 16l19.6 35.6c9.5 19.9 43.1 48.4 41 68.9zm-1.4-25.9c-4.1-6.6-9.6-13.6-14.4-19.6 7.1 0 14.2-2.2 16.7-8.9 2.3-6.2 0-14.9-7.4-24.9-13.5-18.2-38.3-32.5-38.3-32.5-13.5-8.4-21.1-18.7-24.6-29.9s-3-23.3-.3-35.2c5.2-22.9 18.6-45.2 27.2-59.2 2.3-1.7.8 3.2-8.7 20.8-8.5 16.1-24.4 53.3-2.6 82.4.6-20.7 5.5-41.8 13.8-61.5 12-27.4 37.3-74.9 39.3-112.7 1.1.8 4.6 3.2 6.2 4.1 4.6 2.7 8.1 6.7 12.6 10.3 12.4 10 28.5 9.2 42.4 1.2 6.2-3.5 11.2-7.5 15.9-9 9.9-3.1 17.8-8.6 22.3-15 7.7 30.4 25.7 74.3 37.2 95.7 6.1 11.4 18.3 35.5 23.6 64.6 3.3-.1 7 .4 10.9 1.4 13.8-35.7-11.7-74.2-23.3-84.9-4.7-4.6-4.9-6.6-2.6-6.5 12.6 11.2 29.2 33.7 35.2 59 2.8 11.6 3.3 23.7.4 35.7 16.4 6.8 35.9 17.9 30.7 34.8-2.2-.1-3.2 0-4.2 0 3.2-10.1-3.9-17.6-22.8-26.1-19.6-8.6-36-8.6-38.3 12.5-12.1 4.2-18.3 14.7-21.4 27.3-2.8 11.2-3.6 24.7-4.4 39.9-.5 7.7-3.6 18-6.8 29-32.1 22.9-76.7 32.9-114.3 7.2zm257.4-11.5c-.9 16.8-41.2 19.9-63.2 46.5-13.2 15.7-29.4 24.4-43.6 25.5s-26.5-4.8-33.7-19.3c-4.7-11.1-2.4-23.1 1.1-36.3 3.7-14.2 9.2-28.8 9.9-40.6.8-15.2 1.7-28.5 4.2-38.7 2.6-10.3 6.6-17.2 13.7-21.1.3-.2.7-.3 1-.5.8 13.2 7.3 26.6 18.8 29.5 12.6 3.3 30.7-7.5 38.4-16.3 9-.3 15.7-.9 22.6 5.1 9.9 8.5 7.1 30.3 17.1 41.6 10.6 11.6 14 19.5 13.7 24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4s5.9-6.3 3.1-6.6-2.6 2.6-6 5.1c-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2s-18.7-4.8-24.9-9.7c-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z"></path></svg>
-            <div>
-              Linux
-            </div>
-          </button>
-          <button class="os-button-chrome">
-            <!-- Icon from https://fontawesome.com/v5.15/icons/chrome?style=brands -->
-            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 496 512"><path fill="currentColor" d="M131.5 217.5L55.1 100.1c47.6-59.2 119-91.8 192-92.1 42.3-.3 85.5 10.5 124.8 33.2 43.4 25.2 76.4 61.4 97.4 103L264 133.4c-58.1-3.4-113.4 29.3-132.5 84.1zm32.9 38.5c0 46.2 37.4 83.6 83.6 83.6s83.6-37.4 83.6-83.6-37.4-83.6-83.6-83.6-83.6 37.3-83.6 83.6zm314.9-89.2L339.6 174c37.9 44.3 38.5 108.2 6.6 157.2L234.1 503.6c46.5 2.5 94.4-7.7 137.8-32.9 107.4-62 150.9-192 107.4-303.9zM133.7 303.6L40.4 120.1C14.9 159.1 0 205.9 0 256c0 124 90.8 226.7 209.5 244.9l63.7-124.8c-57.6 10.8-113.2-20.8-139.5-72.5z"></path></svg>
-            <div>
-              Chrome
-            </div>
-          </button>
-        </div>
-      </div>
-    </section>
-
-    <section class="changelog">
-      <div>
-        <h2>Changes from v0.8.1 to v0.9.0</h2>
-        <ul>
-          <li>New addon: Paint costume by default</li>
-          <li>New addon: Hide delete button</li>
-          <li>New addon: Do not automatically space overlapping scripts</li>
-          <li class="os-windows">Windows: We now support 32-bit systems</li>
-          <li>You can now create cloud variables. However, they won't actually work unless uploaded to Scratch or a tool such as the TurboWarp Packager</li>
-          <li>Various bug fixes</li>
-          <li>Updated translations</li>
-        </ul>
-        <p class="os-windows" data-l10n="update.windows">To update, download and run the new installer below.</p>
-        <p class="os-mac" data-l10n="update.mac">To update, download and install the new app below.</p>
-        <p class="os-linux" data-l10n="update.linux">If you installed TurboWarp Desktop from an app store or package manager such as the Snap Store, wait until the update is pushed to the store. Otherwise, run the new installer below.</p>
-      </div>
-    </section>
-
-    <section class="os os-windows">
-      <div>
-        <div class="download-button-outer">
-          <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-x64.exe">
-            <div class="download-icon"></div>
-            <div data-l10n="win.download">Download for Windows (64-bit)</div>
-          </a>
-        </div>
-
-        <div class="install-help">
-          <p><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-ia32.exe" data-l10n="win.32">Alternative download for 32-bit systems</a></p>
-          <p data-l10n="win.help">If a Windows SmartScreen alert appears, click "More info" then "Run anyways".</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="os os-mac">
-      <div>
-        <div class="download-button-outer">
-          <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}.dmg">
-            <div class="download-icon"></div>
-            <div data-l10n="mac.download">Download for macOS (Universal)</div>
-          </a>
-        </div>
-
-        <div class="install-help">
-          <div data-l10n="mac.help">If a Gatekeeper prompt appears, open Finder, navigate to Applications, right click TurboWarp and select "Open" and then "Open" again.</div>
-        </div>
-      </div>
-    </section>
-
-    <section class="os os-linux">
-      <div>
-        <p data-l10n="linux.choices">Linux users have some choices.</p>
-        <hr>
-
-        <h2 data-l10n="linux.terminal">Run this in a terminal</h2>
-        <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/install.sh)"</code></p>
-        <p data-l10n="linux.anywhere">Works on any distribution.</p>
-        <hr>
-
-        <h2>Snap Store</h2>
-        <p>
-          <a href="https://snapcraft.io/turbowarp-desktop">
-            <!-- Image from https://github.com/snapcore/snap-store-badges -->
-            <img data-src="snap-store.png" width="182" height="56" alt="Get it from the Snap Store" title="Get it from the Snap Store" data-l10n-attrib="alt=linux.snapTitle,title=linux.snapTitle" style="display: inline;">
-          </a>
-        </p>
-        <hr>
-
-        <h2>Debian, Ubuntu, Raspberry Pi OS, etc.:</h2>
-        <ul>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-amd64-{version}.deb">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.deb">x86 32-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.deb">ARM 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.deb">ARMv7l</a></li>
-        </ul>
-        <hr>
-
-        <h2>AppImage</h2>
-        <ul>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x86_64-{version}.AppImage">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.AppImage">x86 32-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.AppImage">ARM 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.AppImage">ARMv7l</a></li>
-        </ul>
-        <hr>
-
-        <h2>Tarball</h2>
-        <ul>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x64-{version}.tar.gz">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-ia32-{version}.tar.gz">x86 32-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.tar.gz">ARM 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.tar.gz">ARMv7l</a></li>
-        </ul>
-        <hr>
-
-        <h2 data-l10n="linux.uninstall">Uninstall</h2>
-        <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/uninstall.sh)"</code></p>
-      </div>
-    </section>
-
-    <section class="os os-chrome">
-      <div>
-        <div class="download-button-outer">
-          <a class="download-button-inner" href="https://turbowarp.org/" target="_blank" rel="noopener">
-            <div data-l10n="pwa.open">Open the TurboWarp Website</div>
-          </a>
-        </div>
-
-        <div class="install-help">
-          <p data-l10n="pwa.help">Then press the install button in the URL. It may take a few seconds to appear.</p>
-          <img data-src="pwa-install.png" width="620" height="258"class="pwa-install">
-        </div>
-      </div>
-    </section>
-
-    <section class="links">
-      <div class="links-inner">
-        <a class="link" href="https://github.com/TurboWarp/desktop/">
-          <div class="icon">
-            <!-- Icon from https://fontawesome.com/v5.15/icons/code?style=solid -->
-            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg>
-          </div>
-          <div data-l10n="source">Source code</div>
-        </a>
-        <a class="link" href="privacy.html">
-          <div class="icon">
-            <!-- Icon from https://fontawesome.com/v5.15/icons/file?style=solid -->
-            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg>
-          </div>
-          <div data-l10n="privacy">Privacy policy</div>
-        </a>
-        <a class="link" href="https://scratch.mit.edu/users/GarboMuffin/#comments">
-          <div class="icon">
-            <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
-            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
-          </div>
-          <div data-l10n="scratchBugs">Report bugs on Scratch</div>
-        </a>
-        <a class="link" href="https://github.com/TurboWarp/desktop/issues">
-          <div class="icon">
-            <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
-            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
-          </div>
-          <div data-l10n="githubBugs">Report bugs on GitHub</div>
-        </a>
-      </div>
-    </section>
-
-    <section class="picture-container">
-      <img class="picture picture-light" data-src="screenshot-light.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
-      <img class="picture picture-dark" data-src="screenshot-dark.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
-      <p class="picture-caption" data-l10n="picture.caption">Project pictured: <a href="https://scratch.mit.edu/projects/425020125/" data-l10n-subkey="project">Full Sphere Path Tracer by piano_miles</a></p>
-    </section>
-
-    <script>
-      window.L = (function () {
-        const allLanguageMessages = /*===*/{
-"de":{"header.affiliation":"TurboWarp ist nicht mit Scratch, dem Scratch Team oder der Scratch-Stiftung verbunden.","header.subtitle":"Verwende {TurboWarp}, das Scratch-Mod mit einem Compiler, Dunkelmodus, Addons und mehr, mit einer App auf deinem Desktop. Es funktioniert auch, wenn du offline bist.","linux.snapTitle":"Vom Snap-Store holen","picture.caption":"Abgebildetes Projekt: {project}","picture.caption.project":"Full Sphere Path Tracer von piano_miles","picture.title":"Angezeigtes Projekt: Full Sphere Path Tracer von piano_miles","privacy":"Datenschutzerklärung","source":"Quellcode","update.linux":"Falls du TurboWarp Desktop von einem App-Store oder Paketmanager wie dem Snap-Store installiert hast, warte bis das Update im Store verfügbar ist. Ansonsten kannst du unten den neuen Installer ausführen","update.mac":"Lade die neue App herunter und führe sie aus, um TurboWarp zu aktualisieren.","update.windows":"Lade den Installer herunter und führe ihn aus, um TurboWarp zu aktualisieren."},
-"es":{"header.affiliation":"TurboWarp no está afiliado con Scratch, el equipo de Scratch o la Scratch Foundation.","header.subtitle":"Use {TurboWarp}, el mod de Scratch con compilador, modo oscuro, addons y más, desde una app en su escritorio. Funciona incluso sin una conexión a internet.","linux.snapTitle":"Obtener en la Snap Store","picture.caption":"Proyecto en imagen: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Proyecto en la imagen: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidad","source":"Código fuente","update.linux":"Si instaló TurboWarp Desktop desde una tienda de aplicaciones o administrador de paquetes, por ejemplo la Snap Store, espere hasta que la actualización se publique en la tienda. De lo contrario, ejecute el nuevo instalador debajo.","update.mac":"Para actualizar, descargue e instale la app debajo.","update.windows":"Para actualizar, descargue y ejecute el instalador debajo."},
-"fr":{"githubBugs":"Rapporter des bugs sur GitHub","header.affiliation":"TurboWarp n'est pas affilié à Scratch, à l'équipe Scratch ou à la Fondation Scratch.","header.subtitle":"Utilisez {TurboWarp}, le mod Scratch avec un compilateur, un mode sombre, des modules complémentaires et plus encore, à partir d'une application sur votre bureau. Cela fonctionne même lorsque vous êtes hors ligne.","linux.choices":"Les utilisateurs de Linux ont du choix.","linux.terminal":"Lancer dans une console","linux.uninstall":"Désinstaller","mac.download":"Télécharger pour macOS (universel)","privacy":"Politique de Confidentialité","pwa.help":"Appuyez sur le bouton d'installation à l'aide de l'URL. Cela peut prendre quelques secondes à apparaître.","pwa.open":"Ouvrir le site de TurboWarp","scratchBugs":"Rapporter des bugs sur Scratch","source":"Code source","update.linux":"Si vous avez installé TurboWarp Desktop à partir d'un magasin d'applications ou d'un gestionnaire de packages tel que Snap Store, attendez que la mise à jour soit envoyée au magasin. Sinon, exécutez le nouveau programme d'installation ci-dessous.","update.mac":"Pour mettre à jour, téléchargez et installez la nouvelle application ci-dessous.","update.windows":"Pour mettre à jour, téléchargez et exécutez le nouveau programme d'installation ci-dessous.","win.32":"Télécharger pour des systèmes 32-bit","win.download":"Télécharger pour Windows (64-bit)"},
-"it":{"githubBugs":"Notifica i bug su GitHub","header.affiliation":"TurboWarp non è affiliato a Scratch, allo Scratch Team o alla Scratch Foundation.","header.subtitle":"Usa {TurboWarp}, la mod di Scratch dotata di compilatore, dark mode, addon e molto altro come app sul tuo PC. Funziona anche quando non sei online.","linux.anywhere":"Funziona per qualunque distribuzione.","linux.choices":"Gli utenti Linux hanno alcune possibili scelte.","linux.snapTitle":"Ottienilo dallo Snap Store","linux.terminal":"Esegui questo comando in una finestra di Terminale","linux.uninstall":"Disinstalla","mac.download":"Scarica per macOS (Universale)","mac.help":"Se appare un avviso di Gatekeeper apri il Finder, vai ad Applicazioni, clicca TurboWarp con il tasto destro e poi seleziona \"Apri\" e di nuovo \"Apri\".","picture.caption":"Progetto mostrato: {project}","picture.caption.project":"Full Sphere Path Tracer di piano_miles","picture.title":"Progetto: Full Sphere Path Tracer di piano_miles","privacy":"Politica delle privacy","pwa.help":"Premi il pulsante di installazione nella barra dell'indirizzo. Potrebbero essere necessari alcuni secondi prima che appaia.","pwa.open":"Apri il sito TurboWarp","scratchBugs":"Notifica i bug su Scratch","source":"Codice sorgente","update.linux":"Se hai installato TurboWarp Desktop da un app store o usando un gestore di pacchetti come Snap Store attendi fino a che l'aggiornamento è presente nello store. In alternativa puoi eseguire il nuovo installatore che trovi qui sotto.","update.mac":"Per aggiornare, scaricare ed eseguire la nuova app qui sotto.","update.windows":"Per aggiornare, scaricare ed eseguire il nuovo installatore qui sotto.","win.32":"Download alternativi per sistemi a 32-bit:","win.download":"Scarica per Windows (64-bit)","win.help":"Se compare un avviso di Windows, clicca \"More info\" e poi \"Run anyways\""},
-"ja":{"header.affiliation":"TurboWarpはScratch、Scratch Team、Scratch財団と提携していません。","header.subtitle":"コンパイラ、ダークモード、アドオンなどを備えたScratch MOD の{TurboWarp}をデスクトップ上で利用できます。オフラインでも動作します。","linux.snapTitle":"Snap Store で入手できます","picture.caption":"写真のプロジェクト: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"プロジェクトの写真: Full Sphere Path Tracer by piano_miles","privacy":"プライバシーポリシー","source":"ソースコード","update.linux":"アプリストアまたはSnapStoreなどのパッケージマネージャからTurboWarp Desktopをインストールした場合は、アップデートがストアに入るされるまで待って下さい。それ以外の場合は、以下の新規インストーラーを実行してください。","update.mac":"アップデートするには、以下の新しいアプリをダウンロードしてインストールしてください。","update.windows":"更新するには、以下の新しいインストーラーをダウンロードして実行します。"},
-"ko":{"header.affiliation":"TurboWarp는 스크래치, 스크래치 팀,  스크래치 재단에 소속되지 않았습니다.","header.subtitle":"{TurboWarp}를 이용하여 오프라인일 때에도 당신의 컴퓨터에서 스크래치를 다크 모드, 컴파일러, 애드온과 같은 기능을 사용해 보세요.","linux.snapTitle":"Snap Store에서 받기","picture.caption":"프로젝트 캡쳐됨: {project}","picture.caption.project":"piano_miles의 \"Full Sphere Path Tracer\"","picture.title":"piano_miles의 \"Full Sphere Path Tracer\" 프로젝트의 캡쳐","privacy":"개인정보 보호 정책","source":"소스코드","update.linux":"SnapStore와 같은 앱 스토어 또는 패키지 관리자에서 TurboWarp 데스크탑을 설치한 경우 업데이트가 스토어에 올라올 때까지 기다립니다. 그렇지 않은 경우 아래에서 새 설치 프로그램을 실행하세요.","update.mac":"업데이트하려면, 아래의 새 앱을 다운로드하고 설치하세요.","update.windows":"업데이트하려면, 아래의 새 설치기를 다운로드하고 실행하세요."},
-"nb":{"header.affiliation":"TurboWarp er ikke tilknyttet Scratch, Scratch-gruppen eller Scratch Foundation.","header.subtitle":"Bruk {TurboWarp}, Scratch-modet med kompilator, mørkt tema, utvidelser og mer, fra en app på din PC. Det fungerer også når du er offline."},
-"pl":{"githubBugs":"Zgłoś błędy na GitHub","header.affiliation":"TurboWarp nie jest powiązany ze Scratch, Scratch Team, ani Scratch Foundation.","header.subtitle":"Używaj {TurboWarp}, mod Scratcha z kompilatorem, trybem ciemnym, dodatkami i nie tylko. Z aplikacji na pulpicie. Działa nawet, gdy jesteś offline.","linux.snapTitle":"Pobierz go ze sklepu Snap ","linux.terminal":"Uruchom to w terminalu","linux.uninstall":"Oinstaluj","mac.download":"Pobierz dla macOS (Uniwersalny)","mac.help":"Jeżeli pojawi się informacja Gatekeeper, otwórz Finder, przejdź do Aplikacji, prawym przyciskiem kliknij TurboWarp i wybierz \"Otwórz\" i \"Otwórz\" jeszcze raz.","picture.caption":"Projekt na zdjęciu: {project}","picture.caption.project":"Full Sphere Path Tracer autorstwa piano_miles","picture.title":"Pokazany projekt: Full Sphere Path Tracer autorstwa piano_miles","privacy":"Polityka prywatności","pwa.open":"Otwórz Stronę TurboWarp","scratchBugs":"Zgłoś błędy w Scratch","source":"Kod źródłowy","update.linux":"Jeśli zainstalowałeś TurboWarp Desktop ze sklepu z aplikacjami lub menedżera pakietów, takiego jak Snap Store, poczekaj, aż aktualizacja zostanie wypchnięta do sklepu. W przeciwnym razie uruchom nowy instalator poniżej.","update.mac":"Aby zaktualizować, pobierz i zainstaluj nową aplikację poniżej.","update.windows":"Aby zaktualizować, pobierz i uruchom nowy instalator poniżej.","win.32":"Alternatywne pobranie dla 32-bitowych systemów","win.download":"Pobierz dla Windowsa (64-bit)","win.help":"Jeżeli pojawi się alert Windows SmartScreen, kliknij „Więcej informacji”, a następnie „Uruchom mimo wszystko”."},
-"pt":{"header.affiliation":"O TurboWarp não tem afiliação com o Scratch, a Equipe do Scratch ou a Fundação Scratch.","header.subtitle":"Use o {TurboWarp}, o mod do Scratch com um compilador, modo escuro, addons, e mais, em um app no seu computador. Até funciona sem internet.","linux.snapTitle":"Baixe pela Snap Store","picture.caption":"Projeto na imagem: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Projeto na imagem: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidade","source":"Código-fonte","update.linux":"Se você instalou o TurboWarp Desktop de uma loja de aplicativo ou administrador de pacote como a Snap Store, espere até a atualização ser publicada na loja. Senão, rode o novo instalador abaixo.","update.mac":"Para atualizar, baixe e execute o novo aplicativo abaixo.","update.windows":"Para atualizar, baixe e execute o novo instalador abaixo."},
-"ro":{"header.affiliation":"TurboWarp nu este conectat cu Scratch, Echipa Scratch, sau Fundația Scratch."},
-"ru":{"header.affiliation":"TurboWarp не связан с Scratch, Командой Scratch или Фондом Scratch .","header.subtitle":"Используйте {TurboWarp}, модификацию Scratch с компилятором, темным режимом, дополнения и многое другое из приложения на рабочем столе. Оно работает даже в офлайн-режиме.","linux.snapTitle":"Получите в Snap Store","picture.caption":"Изображённый проект: {project}","picture.caption.project":"Full Sphere Path Tracer от piano_miles","picture.title":"Изображённый проект: Full Sphere Path Tracer от piano_miles","privacy":"Политика конфиденциальности","source":"Исходный код","update.linux":"Если вы установили TurboWarp Desktop из магазина приложений или диспетчера пакетов, такого как Snap Store, дождитесь, пока обновление будет отправлено в магазин. В противном случае запустите новый установочный файл ниже.","update.mac":"Чтобы обновить, скачайте и установите приложение ниже.","update.windows":"Чтобы обновить, скачайте и запустите установочный файл ниже."},
-"sl":{"header.affiliation":"TurboWarp ni povezan s Scratchem, skupino Scratch ali fundacijo Scratch.","header.subtitle":"Uporabljajte {TurboWarp}, spremenjeno različico Scratcha s prevajalnikom kode, temnim načinom, dodatki in drugimi funkcijami, kot aplikacijo na svojem računalniku. Deluje tudi brez internetne povezave.","linux.snapTitle":"Namestitev iz trgovine Snap Store","picture.caption":"Projekt na sliki: {project}","picture.caption.project":"Full Sphere Path Tracer avtorja piano_miles","picture.title":"Projekt na sliki: Full Sphere Path Tracer avtorja piano_miles","privacy":"Politika zasebnosti","source":"Izvirna koda","update.linux":"Če ste namestili TurboWarp Desktop s pomočjo trgovine z aplikacijami ali upravitelja paketov, kot je Snap Store, počakajte, dokler posodobitev ni na voljo v trgovini. Sicer zaženite nov namestitveni program spodaj.","update.mac":"Za posodobitev spodaj prenesite in namestite novo aplikacijo.","update.windows":"Za posodobitev spodaj prenesite nov namestitveni program."},
-"sv":{"source":"Källkod"},
-"tr":{"githubBugs":"Hataları GitHub'da bildir","header.affiliation":"TurboWarp, Scratch, Scratch Takım veya Scratch Vakıfı ile bağlantılı değildir.","header.subtitle":"{TurboWarp}'u kullan, bir derleyici olan Scratch modu, karanlık modu, eklentiler ve çevrimdışı olduğunuzda bile çalışır.","linux.anywhere":"Tüm dağıtımlarda çalışır.","linux.choices":"Linux kullanıcılarının bazı seçenekleri vardır.","linux.snapTitle":"Snap Storundan alın","linux.terminal":"Bunu bir terminalde çalıştır","linux.uninstall":"Kaldır","mac.download":"macOS için İndir (Evrensel)","mac.help":"Eğer bir Gatekeeper iletisi gözükürse, Finder'ı açın, Uygulamalar kısmına gidin, TurboWarp'a sağ tıklayın ve \"Aç\" tuşunu seçin, ardından tekrar \"Aç\" tuşuna basın.","picture.caption":"Fotoğrafta gösterilen proje: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"Fotoğrafta gösterilen proje: piano_miles tarafından Full Sphere Path Tracer","privacy":"Gizillik politikası","pwa.help":"Daha sonra URL'deki indir butonuna bas. Görünmesi birkaç saniye alabilir.","pwa.open":"TurboWarp Websitesi'ni Aç","scratchBugs":"Hataları Scratch'te bildir","source":"Kaynak kodu","update.linux":"Eğer Turbowarp Desktop'u bir uygulama mağazasından örneğin Snap Store indirirsen, güncelleme mağazaya aktarılana kadar bekleyin. Aksi takdirde, aşağıdaki yeni yükleyiciyi çalıştırın.","update.mac":"Güncellemek için, yeni yükleyiciği aşağıda indirin.","update.windows":"Güncellemek için, yeni yükleyiciği aşağıda çalıştır.","win.32":"32-bit sistemler için alternatif indirme","win.download":"Windows için İndir (64-bit)","win.help":"Eğer bir Windows SmartScreen uyarısı gözükürse, \"Daha fazla bilgi\" ve ardından \"Yine de çalıştır\" tuşlarına basınız."},
-"zh-cn":{"header.affiliation":"TurboWarp 不属于 Scratch、Scratch 团队或 Scratch 基金会。","header.subtitle":"在你的电脑上使用 {TurboWarp}，一个拥有编译器、深色模式、插件等功能的 Scratch 修改版。它甚至还能在你离线的时候运行。","linux.snapTitle":"从 Snap Store 获取","picture.caption":"图片中的作品：{project}","picture.caption.project":"由 piano_miles 制作的 Full Sphere Path Tracer","picture.title":"图片中的作品：由 piano_miles 制作的 Full Sphere Path Tracer","privacy":"隐私政策","source":"源代码","update.linux":"如果你从像 Snap Store 一样的应用商店或包管理器安装了 TurboWarp Desktop，请等待更新推送到该商店。否则，请运行下面的新安装程序。","update.mac":"在下面下载并安装新的应用程序以更新。","update.windows":"在下面下载并运行新的安装程序以更新。"},
-"zh-tw":{"header.affiliation":"TurboWarp 並不隸屬於 Scratch、Scratch 團隊或 Scratch 基金會。","header.subtitle":"{TurboWarp}，運行更快且帶有黑暗模式、附加元件及其他好用功能的 Scratch，可在電腦和手機上使用，離線亦然。","linux.snapTitle":"從 Snap Store 安裝","picture.caption":"上圖專案：{project}","picture.caption.project":"Full Sphere Path Tracer，作者：piano_miles","picture.title":"上圖專案：Full Sphere Path Tracer，作者：piano_miles","privacy":"隱私政策","source":"原始碼","update.linux":"若你是從應用商店或軟體套件管理系統（如 Snap Store）安裝 TurboWarp 的，就必須等到它放上更新。或者，運行下方的安裝程式。","update.mac":"下載並安裝新版程式以更新。","update.windows":"下載並運行下方的新版安裝程式以更新。"},
-}/*===*/;
-
-        const translatableElements = document.querySelectorAll('[data-l10n]');
-        const translatableAttributes = document.querySelectorAll('[data-l10n-attrib]');
-
-        function getId(el) {
-          if (el.getAttribute('data-l10n-subkey')) return el.getAttribute('data-l10n-subkey');
-          return el.textContent.trim().replace(/\s+/g, '_').replace(/[^a-z_0-9]/gi, '') || ('placeholder' + j);
+          outline: 2px solid black;
         }
 
-        function translate(language) {
-          if (!allLanguageMessages[language]) language = language.split('-')[0];
-          const messages = allLanguageMessages[language];
-          if (!messages) return;
-          document.documentElement.lang = language;
+        @media (prefers-color-scheme: dark) {
+          body {
+            background: #171717;
+            color: #eee;
+          }
+          a {
+            color: #4af;
+          }
+          code, .code {
+            background-color: #222;
+          }
+          a code {
+            color: #4af;
+          }
+          hr {
+            border-color: #333;
+          }
+          .select-os {
+            box-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
+            background: #1a1a1a;
+          }
+          .select-os-inner button {
+            color: white;
+            background-color: rgba(255, 255, 255, 0.2);
+          }
+          .link:hover {
+            background-color: #333;
+          }
+          .picture-dark {
+            display: block;
+          }
+          .picture-light {
+            display: none;
+          }
+          :focus-visible {
+            outline: 2px solid white;
+          }
+        }
+      </style>
+    </head>
 
-          for (const el of translatableElements) {
-            const nodes = el.childNodes;
-            const namedNodes = {};
-            const key = el.getAttribute('data-l10n');
-            const message = messages[key];
+    <!--
+      Some icons are from Font Awesome https://fontawesome.com/
+      For license information, visit https://creativecommons.org/licenses/by/4.0/
+      Icons have been minified by hand.
+    -->
 
-            if (!message) {
-              console.warn('Missing message: ' + key);
-              continue;
-            }
+    <body os="">
+      <section class="header visible-loading">
+        <div>
+          <h1 class="header-title">
+            <svg aria-hidden="true" viewBox="0 0 1024 1024">
+              <path d="m64 174.86735v641.13265c0 35.34622 28.653776 64 64 64h113.30332c9.32935 0 18.19416 4.07135 24.27337 11.14807l67.26992 78.30776c12.15843 14.15343 29.88806 22.29614 48.54676 22.29614h261.21326c18.6587 0 36.38832-8.14271 48.54676-22.29614l67.26992-78.30776c6.07921-7.07672 14.94402-11.14807 24.27337-11.14807h113.30332c35.34622 0 64-28.65378 64-64v-654.84694c0-35.34622-28.65378-64-64-64-0.38091 0-0.76182 0.0034-1.14268 0.0102l-767.99999 13.71429c-34.89522 0.62313-62.85733 29.08902-62.85733 63.9898z" fill="#cc3c3c" fill-rule="evenodd"/>
+              <path d="m64 96v672c0 35.34622 28.653776 64 64 64h128.17394c9.97413 0 19.37789 4.65076 25.43168 12.5776l51.18313 67.01917c12.1076 15.85368 30.9151 25.1552 50.86336 25.1552h256.69578c19.94826 0 38.75576-9.30152 50.86336-25.1552l51.18312-67.01917c6.0538-7.92684 15.45756-12.5776 25.43169-12.5776h128.17394c35.34622 0 64-28.65378 64-64v-672c0-35.346224-28.65378-64-64-64h-768c-35.346224 0-64 28.653776-64 64z" fill="#ff4c4c" fill-rule="evenodd"/>
+              <path d="m96 96v672c0 17.67311 14.32689 32 32 32h128.17394c19.94827 0 38.75577 9.30152 50.86337 25.1552l51.18312 67.01917c6.0538 7.92684 15.45755 12.5776 25.43168 12.5776h256.69578c9.97413 0 19.37788-4.65076 25.43168-12.5776l51.18312-67.01917c12.1076-15.85368 30.9151-25.1552 50.86337-25.1552h128.17394c17.67311 0 32-14.32689 32-32v-672c0-17.673112-14.32689-32-32-32h-768c-17.67311 0-32 14.326888-32 32zm-32 0c0-35.346224 28.653776-64 64-64h768c35.34622 0 64 28.653776 64 64v672c0 35.34622-28.65378 64-64 64h-128.17394c-9.97413 0-19.37789 4.65076-25.43169 12.5776l-51.18312 67.01917c-12.1076 15.85368-30.9151 25.1552-50.86336 25.1552h-256.69578c-19.94826 0-38.75576-9.30152-50.86336-25.1552l-51.18313-67.01917c-6.05379-7.92684-15.45755-12.5776-25.43168-12.5776h-128.17394c-35.346224 0-64-28.65378-64-64z" fill="#fff" fill-opacity=".2"/>
+              <g transform="matrix(4.1943736,0,0,4.1943736,229.13567,171.21359)" fill="none" stroke="#fff" stroke-width="56.4093">
+               <path d="m108.34581 31.577677c-0.79395 3.473563-1.38942 7.244861-1.7864 11.313892-0.0992 1.091691 0 2.481117 0.29773 4.168276 0.29773 1.984893 0.4466 3.374319 0.4466 4.168276 0 2.580361-1.68716 3.870542-5.06147 3.870542-2.18339 0-3.622435-0.64509-4.317148-1.935271-0.09925-2.183383-0.04962-5.160723 0.14887-8.93202 0.198487-4.46601 0.29773-7.44335 0.29773-8.93202-0.09924 0-0.248107-0.09924-0.4466-0.297734-9.229753 0.396979-17.91366 0.992447-26.05172 1.786404-0.198493 1.290181-0.198493 2.878095 0 4.763744l0.59546 5.359212c-0.396973 3.076585-0.59546 7.64184-0.59546 13.695765 0.297733 2.580361 0.4466 13.646143 0.4466 33.197344v10.867303c0 1.68716 0.24811 2.8781 0.74433 3.57281h9.22976c3.771293-0.49623 5.65694 1.09169 5.65694 4.76374 0 2.18339-1.042067 3.72168-3.1262 4.61488-1.290187 0.49623-3.572817 0.59547-6.84789 0.29774-1.984893-0.19849-4.317143-0.24812-6.99675-0.14887-3.672053 0.49622-8.138063 0.8932-13.39803 1.19093-5.359207 0.29774-8.634279-0.44659-9.825218-2.233-0.793957-1.19093-0.793957-2.43149 0-3.72168 1.389425-2.18338 5.011855-3.27507 10.867288-3.27507 3.076587 0 4.61488-0.84358 4.61488-2.53074 0-0.8932-0.04962-1.73678-0.14887-2.53074 0-2.48113 0.04962-4.66452 0.14887-6.550163 0.297733-5.359213 0.297733-12.901808 0-22.627784-0.39698-14.092743-0.248113-26.746439 0.4466-37.961086l-0.4466-0.446601c-3.076587 0.198489-8.832777 0.148867-17.268572-0.148867-0.396979 0-3.423941 0.198489-9.080887 0.595468 1.389425 9.527488 2.183383 16.325748 2.381872 20.394779l-0.297734 4.01941c-0.09924 1.48867-1.339803 2.233005-3.721676 2.233005-1.885649 0-3.473563-3.572808-4.763744-10.718425-0.595468-4.267521-1.190936-8.584664-1.786404-12.951429 0-0.694713-0.347356-1.885649-1.042069-3.572808-0.595468-1.786404-1.908676-4.750966-1.908676-5.644168 0-3.141175 2.901123-2.39465 6.67242-2.990118 0.297734 0 0.793957 0.04962 1.48867 0.148867 0.694713 0.09924 1.190936 0.148867 1.48867 0.148867h36.91902c9.130507-0.396979 17.96328-1.190936 26.49832-2.381872 0.595473-0.297734 1.488678-0.595468 2.679608-0.893202 2.08414-0.19849 3.87054 0.297733 5.35921 1.48867 1.48867 1.091691 1.9849 2.679606 1.48867 4.763744z" fill="none" stroke="#fff" stroke-width="56.4093"/>
+              </g>
+              <g transform="matrix(3.852509,0,0,3.852509,257.89982,219.83848)" fill="none" stroke="#ff4c4c" stroke-width="30.7075">
+               <path d="m110.38498 21.776581q-1.29661 5.672702-1.94492 12.317866-0.16208 1.782849 0.32415 4.538161 0.48623 3.241544 0.48623 4.538161 0 4.214007-5.51062 4.214007-3.5657 0-4.700239-2.107004-0.16208-3.565698 0.16208-9.72463 0.32415-7.293474 0.32415-9.724631-0.16207 0-0.48623-0.324155-15.073176 0.648309-28.3635 1.944927-0.324161 2.107003 0 5.186469l0.6483 5.834779q-0.6483 5.024392-0.6483 14.911102 0.48623 4.214006 0.48623 36.143214v11.831633q0 2.75531 0.81038 3.88985h10.048792q6.158927-0.81039 6.158927 5.18647 0 3.5657-3.403614 5.0244-2.107013 0.81039-7.455559 0.32416-3.241543-0.32416-7.617628-0.16208-5.996857 0.81038-14.586946 1.29661-8.75216 0.48624-10.69709-2.43115-1.296617-1.94493 0-4.05194 2.26908-3.56569 11.831631-3.56569 5.024396 0 5.024396-2.75532 0-1.45869-0.162081-2.75531 0-4.051935 0.162081-7.131398 0.48623-8.75217 0-24.635731-0.648311-23.014961 0.48623-41.329683l-0.48623-0.486231q-5.024396 0.324154-18.800953-0.162077-0.648309 0-9.886708 0.648308 2.26908 15.55941 2.593235 22.204574 0 0-0.324155 4.376085-0.162077 2.431158-4.05193 2.431158-3.079467 0-5.18647-11.669558-0.972463-6.969319-1.944926-14.100715 0-1.13454-1.134541-3.889852-0.972463-2.91739-0.972463-4.376084 0-4.05193 6.158933-5.024393 0.486232 0 1.620772 0.162077 1.13454 0.162078 1.620772 0.162078h16.856029q23.339116 0 23.339116 0 14.911096-0.648309 28.849729-2.593235 0.97247-0.486232 2.91739-0.972463 3.40363-0.324156 5.83478 1.620771 2.43116 1.782849 1.62077 5.18647z" fill="none" stroke="#ff4c4c" stroke-width="30.7075"/>
+              </g>
+              <g transform="matrix(4.1943736,0,0,4.1943736,228.25358,197.35677)" fill="#fff">
+               <path d="m108.34581 25.3789q-1.19093 5.210345-1.7864 11.313892-0.14887 1.637537 0.29773 4.168276 0.4466 2.97734 0.4466 4.168276 0 3.870542-5.06147 3.870542-3.275078 0-4.317148-1.935271-0.14887-3.275074 0.14887-8.93202 0.29773-6.699015 0.29773-8.93202-0.14886 0-0.4466-0.297734-13.84463 0.595468-26.05172 1.786404-0.29774 1.935271 0 4.763744l0.59546 5.359212q-0.59546 4.614877-0.59546 13.695765 0.4466 3.870542 0.4466 33.197344v10.86729q0 2.53074 0.74433 3.57281h9.22976q5.65694-0.74434 5.65694 4.76374 0 3.27508-3.1262 4.61488-1.93528 0.74434-6.84789 0.29774-2.97734-0.29774-6.99675-0.14887-5.50808 0.74433-13.39803 1.19093-8.03881 0.44661-9.825218-2.233-1.190936-1.7864 0-3.72168 2.084138-3.27507 10.867288-3.27507 4.61488 0 4.61488-2.53074 0-1.3398-0.14887-2.53074 0-3.72168 0.14887-6.55015 0.4466-8.03882 0-22.627784-0.59547-21.139115 0.4466-37.961086l-0.4466-0.446601q-4.61488 0.297734-17.268572-0.148867-0.595468 0-9.080887 0.595468 2.084138 14.291232 2.381872 20.394779 0 0-0.297734 4.01941-0.148867 2.233005-3.721676 2.233005-2.828473 0-4.763744-10.718425-0.893202-6.401281-1.786404-12.951429 0-1.042069-1.042069-3.572808-0.893202-2.679606-0.893202-4.019409 0-3.721675 5.656946-4.614877 0.446601 0 1.48867 0.148867t1.48867 0.148867h15.48217q21.43685 0 21.43685 0 13.69576-0.595468 26.49832-2.381872 0.89321-0.446601 2.679608-0.893202 3.12621-0.297735 5.35921 1.48867 2.23301 1.637537 1.48867 4.763744z" fill="#fff"/>
+              </g>
+            </svg>
+            <div>TurboWarp Desktop</div>
+          </h1>
+          <div class="header-subtitles">
+            <noscript><p>This page requires JavaScript.</p></noscript>
+            <p data-l10n="header.subtitle" class="transparent-loading">Use <a href="https://turbowarp.org" data-notranslate>TurboWarp</a>, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop. It even works when you're offline!</p>
+            <p class="transparent-loading"><i data-l10n="header.affiliation">TurboWarp is not affiliated with Scratch, the Scratch Team, or the Scratch Foundation.</i></p>
+          </div>
+        </div>
+      </section>
 
-            for (const node of nodes) {
-              if (node.nodeName === '#text') continue;
-              const id = getId(node);
-              namedNodes[id] = node;
-              const message = messages[key + '.' + id];
-              if (message) {
-                node.textContent = message;
-              }
-            }
+      <section class="select-os" id="select-os">
+        <div class="select-os-inner">
+          <div class="select-os-buttons">
+            <button class="os-button-windows">
+              <!-- Icon from https://fontawesome.com/icons/windows?style=brands -->
+              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"></path></svg>
+              <div>
+                Windows
+              </div>
+            </button>
+            <button class="os-button-mac">
+              <!-- Icon from https://fontawesome.com/icons/apple?style=brands -->
+              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"></path></svg>
+              <div>
+                macOS
+              </div>
+            </button>
+            <button class="os-button-linux">
+              <!-- Icon from https://fontawesome.com/icons/linux?style=brands -->
+              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-6.5 5.8-11.4 14.7-16.6 20.2-4.2 4.3-10.3 5.9-17 8.3s-14 6-18.5 14.5c-2.1 3.9-2.8 8.1-2.8 12.4 0 3.9.6 7.9 1.2 11.8 1.2 8.1 2.5 15.7.8 20.8-5.2 14.4-5.9 24.4-2.2 31.7 3.8 7.3 11.4 10.5 20.1 12.3 17.3 3.6 40.8 2.7 59.3 12.5 19.8 10.4 39.9 14.1 55.9 10.4 11.6-2.6 21.1-9.6 25.9-20.2 12.5-.1 26.3-5.4 48.3-6.6 14.9-1.2 33.6 5.3 55.1 4.1.6 2.3 1.4 4.6 2.5 6.7v.1c8.3 16.7 23.8 24.3 40.3 23 16.6-1.3 34.1-11 48.3-27.9 13.6-16.4 36-23.2 50.9-32.2 7.4-4.5 13.4-10.1 13.9-18.3.4-8.2-4.4-17.3-15.5-29.7zM223.7 87.3c9.8-22.2 34.2-21.8 44-.4 6.5 14.2 3.6 30.9-4.3 40.4-1.6-.8-5.9-2.6-12.6-4.9 1.1-1.2 3.1-2.7 3.9-4.6 4.8-11.8-.2-27-9.1-27.3-7.3-.5-13.9 10.8-11.8 23-4.1-2-9.4-3.5-13-4.4-1-6.9-.3-14.6 2.9-21.8zM183 75.8c10.1 0 20.8 14.2 19.1 33.5-3.5 1-7.1 2.5-10.2 4.6 1.2-8.9-3.3-20.1-9.6-19.6-8.4.7-9.8 21.2-1.8 28.1 1 .8 1.9-.2-5.9 5.5-15.6-14.6-10.5-52.1 8.4-52.1zm-13.6 60.7c6.2-4.6 13.6-10 14.1-10.5 4.7-4.4 13.5-14.2 27.9-14.2 7.1 0 15.6 2.3 25.9 8.9 6.3 4.1 11.3 4.4 22.6 9.3 8.4 3.5 13.7 9.7 10.5 18.2-2.6 7.1-11 14.4-22.7 18.1-11.1 3.6-19.8 16-38.2 14.9-3.9-.2-7-1-9.6-2.1-8-3.5-12.2-10.4-20-15-8.6-4.8-13.2-10.4-14.7-15.3-1.4-4.9 0-9 4.2-12.3zm3.3 334c-2.7 35.1-43.9 34.4-75.3 18-29.9-15.8-68.6-6.5-76.5-21.9-2.4-4.7-2.4-12.7 2.6-26.4v-.2c2.4-7.6.6-16-.6-23.9-1.2-7.8-1.8-15 .9-20 3.5-6.7 8.5-9.1 14.8-11.3 10.3-3.7 11.8-3.4 19.6-9.9 5.5-5.7 9.5-12.9 14.3-18 5.1-5.5 10-8.1 17.7-6.9 8.1 1.2 15.1 6.8 21.9 16l19.6 35.6c9.5 19.9 43.1 48.4 41 68.9zm-1.4-25.9c-4.1-6.6-9.6-13.6-14.4-19.6 7.1 0 14.2-2.2 16.7-8.9 2.3-6.2 0-14.9-7.4-24.9-13.5-18.2-38.3-32.5-38.3-32.5-13.5-8.4-21.1-18.7-24.6-29.9s-3-23.3-.3-35.2c5.2-22.9 18.6-45.2 27.2-59.2 2.3-1.7.8 3.2-8.7 20.8-8.5 16.1-24.4 53.3-2.6 82.4.6-20.7 5.5-41.8 13.8-61.5 12-27.4 37.3-74.9 39.3-112.7 1.1.8 4.6 3.2 6.2 4.1 4.6 2.7 8.1 6.7 12.6 10.3 12.4 10 28.5 9.2 42.4 1.2 6.2-3.5 11.2-7.5 15.9-9 9.9-3.1 17.8-8.6 22.3-15 7.7 30.4 25.7 74.3 37.2 95.7 6.1 11.4 18.3 35.5 23.6 64.6 3.3-.1 7 .4 10.9 1.4 13.8-35.7-11.7-74.2-23.3-84.9-4.7-4.6-4.9-6.6-2.6-6.5 12.6 11.2 29.2 33.7 35.2 59 2.8 11.6 3.3 23.7.4 35.7 16.4 6.8 35.9 17.9 30.7 34.8-2.2-.1-3.2 0-4.2 0 3.2-10.1-3.9-17.6-22.8-26.1-19.6-8.6-36-8.6-38.3 12.5-12.1 4.2-18.3 14.7-21.4 27.3-2.8 11.2-3.6 24.7-4.4 39.9-.5 7.7-3.6 18-6.8 29-32.1 22.9-76.7 32.9-114.3 7.2zm257.4-11.5c-.9 16.8-41.2 19.9-63.2 46.5-13.2 15.7-29.4 24.4-43.6 25.5s-26.5-4.8-33.7-19.3c-4.7-11.1-2.4-23.1 1.1-36.3 3.7-14.2 9.2-28.8 9.9-40.6.8-15.2 1.7-28.5 4.2-38.7 2.6-10.3 6.6-17.2 13.7-21.1.3-.2.7-.3 1-.5.8 13.2 7.3 26.6 18.8 29.5 12.6 3.3 30.7-7.5 38.4-16.3 9-.3 15.7-.9 22.6 5.1 9.9 8.5 7.1 30.3 17.1 41.6 10.6 11.6 14 19.5 13.7 24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4s5.9-6.3 3.1-6.6-2.6 2.6-6 5.1c-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2s-18.7-4.8-24.9-9.7c-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z"></path></svg>
+              <div>
+                Linux
+              </div>
+            </button>
+            <button class="os-button-chrome">
+              <!-- Icon from https://fontawesome.com/v5.15/icons/chrome?style=brands -->
+              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 496 512"><path fill="currentColor" d="M131.5 217.5L55.1 100.1c47.6-59.2 119-91.8 192-92.1 42.3-.3 85.5 10.5 124.8 33.2 43.4 25.2 76.4 61.4 97.4 103L264 133.4c-58.1-3.4-113.4 29.3-132.5 84.1zm32.9 38.5c0 46.2 37.4 83.6 83.6 83.6s83.6-37.4 83.6-83.6-37.4-83.6-83.6-83.6-83.6 37.3-83.6 83.6zm314.9-89.2L339.6 174c37.9 44.3 38.5 108.2 6.6 157.2L234.1 503.6c46.5 2.5 94.4-7.7 137.8-32.9 107.4-62 150.9-192 107.4-303.9zM133.7 303.6L40.4 120.1C14.9 159.1 0 205.9 0 256c0 124 90.8 226.7 209.5 244.9l63.7-124.8c-57.6 10.8-113.2-20.8-139.5-72.5z"></path></svg>
+              <div>
+                Chrome
+              </div>
+            </button>
+          </div>
+        </div>
+      </section>
 
-            while (el.firstChild) el.removeChild(el.firstChild);
+      <section class="changelog">
+        <div>
+          <h2>Changes from v0.8.1 to v0.9.0</h2>
+          <ul>
+            <li>New addon: Paint costume by default</li>
+            <li>New addon: Hide delete button</li>
+            <li>New addon: Do not automatically space overlapping scripts</li>
+            <li class="os-windows">Windows: We now support 32-bit systems</li>
+            <li>You can now create cloud variables. However, they won't actually work unless uploaded to Scratch or a tool such as the TurboWarp Packager</li>
+            <li>Various bug fixes</li>
+            <li>Updated translations</li>
+          </ul>
+          <p class="os-windows" data-l10n="update.windows">To update, download and run the new installer below.</p>
+          <p class="os-mac" data-l10n="update.mac">To update, download and install the new app below.</p>
+          <p class="os-linux" data-l10n="update.linux">If you installed TurboWarp Desktop from an app store or package manager such as the Snap Store, wait until the update is pushed to the store. Otherwise, run the new installer below.</p>
+        </div>
+      </section>
 
-            const messageParts = message.split(/{|}/g);
-            for (let i = 0; i < messageParts.length; i++) {
-              const part = messageParts[i];
-              if (i % 2 === 0) {
-                el.appendChild(document.createTextNode(part));
-              } else {
-                const node = namedNodes[part];
-                if (!node) {
-                  console.warn('Missing named node: ' + part);
-                  continue;
-                }
-                el.appendChild(node);
-              }
-            }
+      <section class="os os-windows">
+        <div>
+          <div class="download-button-outer">
+            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-x64.exe">
+              <div class="download-icon"></div>
+              <div data-l10n="win.download">Download for Windows (64-bit)</div>
+            </a>
+          </div>
+          
+          &nbsp;
+
+          <div class="download-button-outer">
+            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-ia32.exe">
+              <div class="download-icon"></div>
+              <div data-l10n="win.download">Download for Windows (32-bit)</div>
+            </a>
+          </div>
+          
+          <div class="install-help">
+            <p data-l10n="win.help">If a Windows SmartScreen alert appears, click "More info" then "Run anyways".</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="os os-mac">
+        <div>
+          <div class="download-button-outer">
+            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}.dmg">
+              <div class="download-icon"></div>
+              <div data-l10n="mac.download">Download for macOS (Universal)</div>
+            </a>
+          </div>
+
+          <div class="install-help">
+            <div data-l10n="mac.help">If a Gatekeeper prompt appears, open Finder, navigate to Applications, right click TurboWarp and select "Open" and then "Open" again.</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="os os-linux">
+        <div>
+          <p data-l10n="linux.choices">Linux users have some choices.</p>
+          <hr>
+
+          <h2 data-l10n="linux.terminal">Run this in a terminal</h2>
+          <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/install.sh)"</code></p>
+          <p data-l10n="linux.anywhere">Works on any distribution.</p>
+          <hr>
+
+          <h2>Snap Store</h2>
+          <p>
+            <a href="https://snapcraft.io/turbowarp-desktop">
+              <!-- Image from https://github.com/snapcore/snap-store-badges -->
+              <img data-src="snap-store.png" width="182" height="56" alt="Get it from the Snap Store" title="Get it from the Snap Store" data-l10n-attrib="alt=linux.snapTitle,title=linux.snapTitle" style="display: inline;">
+            </a>
+          </p>
+          <hr>
+
+          <h2>Debian, Ubuntu, Raspberry Pi OS, etc.:</h2>
+          <ul>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-amd64-{version}.deb">x86 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.deb">x86 32-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.deb">ARM 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.deb">ARMv7l</a></li>
+          </ul>
+          <hr>
+
+          <h2>AppImage</h2>
+          <ul>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x86_64-{version}.AppImage">x86 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.AppImage">x86 32-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.AppImage">ARM 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.AppImage">ARMv7l</a></li>
+          </ul>
+          <hr>
+
+          <h2>Tarball</h2>
+          <ul>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x64-{version}.tar.gz">x86 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-ia32-{version}.tar.gz">x86 32-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.tar.gz">ARM 64-bit</a></li>
+            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.tar.gz">ARMv7l</a></li>
+          </ul>
+          <hr>
+
+          <h2 data-l10n="linux.uninstall">Uninstall</h2>
+          <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/uninstall.sh)"</code></p>
+        </div>
+      </section>
+
+      <section class="os os-chrome">
+        <div>
+          <div class="download-button-outer">
+            <a class="download-button-inner" href="https://turbowarp.org/" target="_blank" rel="noopener">
+              <div data-l10n="pwa.open">Open the TurboWarp Website</div>
+            </a>
+          </div>
+
+          <div class="install-help">
+            <p data-l10n="pwa.help">Then press the install button in the URL. It may take a few seconds to appear.</p>
+            <img data-src="pwa-install.png" width="620" height="258"class="pwa-install">
+          </div>
+        </div>
+      </section>
+
+      <section class="links">
+        <div class="links-inner">
+          <a class="link" href="https://github.com/TurboWarp/desktop/">
+            <div class="icon">
+              <!-- Icon from https://fontawesome.com/v5.15/icons/code?style=solid -->
+              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg>
+            </div>
+            <div data-l10n="source">Source code</div>
+          </a>
+          <a class="link" href="privacy.html">
+            <div class="icon">
+              <!-- Icon from https://fontawesome.com/v5.15/icons/file?style=solid -->
+              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg>
+            </div>
+            <div data-l10n="privacy">Privacy policy</div>
+          </a>
+          <a class="link" href="https://scratch.mit.edu/users/GarboMuffin/#comments">
+            <div class="icon">
+              <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
+              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
+            </div>
+            <div data-l10n="scratchBugs">Report bugs on Scratch</div>
+          </a>
+          <a class="link" href="https://github.com/TurboWarp/desktop/issues">
+            <div class="icon">
+              <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
+              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
+            </div>
+            <div data-l10n="githubBugs">Report bugs on GitHub</div>
+          </a>
+        </div>
+      </section>
+
+      <section class="picture-container">
+        <img class="picture picture-light" data-src="screenshot-light.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
+        <img class="picture picture-dark" data-src="screenshot-dark.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
+        <p class="picture-caption" data-l10n="picture.caption">Project pictured: <a href="https://scratch.mit.edu/projects/425020125/" data-l10n-subkey="project">Full Sphere Path Tracer by piano_miles</a></p>
+      </section>
+
+      <script>
+        window.L = (function () {
+          const allLanguageMessages = /*===*/{
+  "de":{"header.affiliation":"TurboWarp ist nicht mit Scratch, dem Scratch Team oder der Scratch-Stiftung verbunden.","header.subtitle":"Verwende {TurboWarp}, das Scratch-Mod mit einem Compiler, Dunkelmodus, Addons und mehr, mit einer App auf deinem Desktop. Es funktioniert auch, wenn du offline bist.","linux.snapTitle":"Vom Snap-Store holen","picture.caption":"Abgebildetes Projekt: {project}","picture.caption.project":"Full Sphere Path Tracer von piano_miles","picture.title":"Angezeigtes Projekt: Full Sphere Path Tracer von piano_miles","privacy":"Datenschutzerklärung","source":"Quellcode","update.linux":"Falls du TurboWarp Desktop von einem App-Store oder Paketmanager wie dem Snap-Store installiert hast, warte bis das Update im Store verfügbar ist. Ansonsten kannst du unten den neuen Installer ausführen","update.mac":"Lade die neue App herunter und führe sie aus, um TurboWarp zu aktualisieren.","update.windows":"Lade den Installer herunter und führe ihn aus, um TurboWarp zu aktualisieren."},
+  "es":{"header.affiliation":"TurboWarp no está afiliado con Scratch, el equipo de Scratch o la Scratch Foundation.","header.subtitle":"Use {TurboWarp}, el mod de Scratch con compilador, modo oscuro, addons y más, desde una app en su escritorio. Funciona incluso sin una conexión a internet.","linux.snapTitle":"Obtener en la Snap Store","picture.caption":"Proyecto en imagen: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Proyecto en la imagen: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidad","source":"Código fuente","update.linux":"Si instaló TurboWarp Desktop desde una tienda de aplicaciones o administrador de paquetes, por ejemplo la Snap Store, espere hasta que la actualización se publique en la tienda. De lo contrario, ejecute el nuevo instalador debajo.","update.mac":"Para actualizar, descargue e instale la app debajo.","update.windows":"Para actualizar, descargue y ejecute el instalador debajo."},
+  "fr":{"githubBugs":"Rapporter des bugs sur GitHub","header.affiliation":"TurboWarp n'est pas affilié à Scratch, à l'équipe Scratch ou à la Fondation Scratch.","header.subtitle":"Utilisez {TurboWarp}, le mod Scratch avec un compilateur, un mode sombre, des modules complémentaires et plus encore, à partir d'une application sur votre bureau. Cela fonctionne même lorsque vous êtes hors ligne.","linux.choices":"Les utilisateurs de Linux ont du choix.","linux.terminal":"Lancer dans une console","linux.uninstall":"Désinstaller","mac.download":"Télécharger pour macOS (universel)","privacy":"Politique de Confidentialité","pwa.help":"Appuyez sur le bouton d'installation à l'aide de l'URL. Cela peut prendre quelques secondes à apparaître.","pwa.open":"Ouvrir le site de TurboWarp","scratchBugs":"Rapporter des bugs sur Scratch","source":"Code source","update.linux":"Si vous avez installé TurboWarp Desktop à partir d'un magasin d'applications ou d'un gestionnaire de packages tel que Snap Store, attendez que la mise à jour soit envoyée au magasin. Sinon, exécutez le nouveau programme d'installation ci-dessous.","update.mac":"Pour mettre à jour, téléchargez et installez la nouvelle application ci-dessous.","update.windows":"Pour mettre à jour, téléchargez et exécutez le nouveau programme d'installation ci-dessous.","win.32":"Télécharger pour des systèmes 32-bit","win.download":"Télécharger pour Windows (64-bit)"},
+  "it":{"githubBugs":"Notifica i bug su GitHub","header.affiliation":"TurboWarp non è affiliato a Scratch, allo Scratch Team o alla Scratch Foundation.","header.subtitle":"Usa {TurboWarp}, la mod di Scratch dotata di compilatore, dark mode, addon e molto altro come app sul tuo PC. Funziona anche quando non sei online.","linux.anywhere":"Funziona per qualunque distribuzione.","linux.choices":"Gli utenti Linux hanno alcune possibili scelte.","linux.snapTitle":"Ottienilo dallo Snap Store","linux.terminal":"Esegui questo comando in una finestra di Terminale","linux.uninstall":"Disinstalla","mac.download":"Scarica per macOS (Universale)","mac.help":"Se appare un avviso di Gatekeeper apri il Finder, vai ad Applicazioni, clicca TurboWarp con il tasto destro e poi seleziona \"Apri\" e di nuovo \"Apri\".","picture.caption":"Progetto mostrato: {project}","picture.caption.project":"Full Sphere Path Tracer di piano_miles","picture.title":"Progetto: Full Sphere Path Tracer di piano_miles","privacy":"Politica delle privacy","pwa.help":"Premi il pulsante di installazione nella barra dell'indirizzo. Potrebbero essere necessari alcuni secondi prima che appaia.","pwa.open":"Apri il sito TurboWarp","scratchBugs":"Notifica i bug su Scratch","source":"Codice sorgente","update.linux":"Se hai installato TurboWarp Desktop da un app store o usando un gestore di pacchetti come Snap Store attendi fino a che l'aggiornamento è presente nello store. In alternativa puoi eseguire il nuovo installatore che trovi qui sotto.","update.mac":"Per aggiornare, scaricare ed eseguire la nuova app qui sotto.","update.windows":"Per aggiornare, scaricare ed eseguire il nuovo installatore qui sotto.","win.32":"Download alternativi per sistemi a 32-bit:","win.download":"Scarica per Windows (64-bit)","win.help":"Se compare un avviso di Windows, clicca \"More info\" e poi \"Run anyways\""},
+  "ja":{"header.affiliation":"TurboWarpはScratch、Scratch Team、Scratch財団と提携していません。","header.subtitle":"コンパイラ、ダークモード、アドオンなどを備えたScratch MOD の{TurboWarp}をデスクトップ上で利用できます。オフラインでも動作します。","linux.snapTitle":"Snap Store で入手できます","picture.caption":"写真のプロジェクト: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"プロジェクトの写真: Full Sphere Path Tracer by piano_miles","privacy":"プライバシーポリシー","source":"ソースコード","update.linux":"アプリストアまたはSnapStoreなどのパッケージマネージャからTurboWarp Desktopをインストールした場合は、アップデートがストアに入るされるまで待って下さい。それ以外の場合は、以下の新規インストーラーを実行してください。","update.mac":"アップデートするには、以下の新しいアプリをダウンロードしてインストールしてください。","update.windows":"更新するには、以下の新しいインストーラーをダウンロードして実行します。"},
+  "ko":{"header.affiliation":"TurboWarp는 스크래치, 스크래치 팀,  스크래치 재단에 소속되지 않았습니다.","header.subtitle":"{TurboWarp}를 이용하여 오프라인일 때에도 당신의 컴퓨터에서 스크래치를 다크 모드, 컴파일러, 애드온과 같은 기능을 사용해 보세요.","linux.snapTitle":"Snap Store에서 받기","picture.caption":"프로젝트 캡쳐됨: {project}","picture.caption.project":"piano_miles의 \"Full Sphere Path Tracer\"","picture.title":"piano_miles의 \"Full Sphere Path Tracer\" 프로젝트의 캡쳐","privacy":"개인정보 보호 정책","source":"소스코드","update.linux":"SnapStore와 같은 앱 스토어 또는 패키지 관리자에서 TurboWarp 데스크탑을 설치한 경우 업데이트가 스토어에 올라올 때까지 기다립니다. 그렇지 않은 경우 아래에서 새 설치 프로그램을 실행하세요.","update.mac":"업데이트하려면, 아래의 새 앱을 다운로드하고 설치하세요.","update.windows":"업데이트하려면, 아래의 새 설치기를 다운로드하고 실행하세요."},
+  "nb":{"header.affiliation":"TurboWarp er ikke tilknyttet Scratch, Scratch-gruppen eller Scratch Foundation.","header.subtitle":"Bruk {TurboWarp}, Scratch-modet med kompilator, mørkt tema, utvidelser og mer, fra en app på din PC. Det fungerer også når du er offline."},
+  "pl":{"githubBugs":"Zgłoś błędy na GitHub","header.affiliation":"TurboWarp nie jest powiązany ze Scratch, Scratch Team, ani Scratch Foundation.","header.subtitle":"Używaj {TurboWarp}, mod Scratcha z kompilatorem, trybem ciemnym, dodatkami i nie tylko. Z aplikacji na pulpicie. Działa nawet, gdy jesteś offline.","linux.snapTitle":"Pobierz go ze sklepu Snap ","linux.terminal":"Uruchom to w terminalu","linux.uninstall":"Oinstaluj","mac.download":"Pobierz dla macOS (Uniwersalny)","mac.help":"Jeżeli pojawi się informacja Gatekeeper, otwórz Finder, przejdź do Aplikacji, prawym przyciskiem kliknij TurboWarp i wybierz \"Otwórz\" i \"Otwórz\" jeszcze raz.","picture.caption":"Projekt na zdjęciu: {project}","picture.caption.project":"Full Sphere Path Tracer autorstwa piano_miles","picture.title":"Pokazany projekt: Full Sphere Path Tracer autorstwa piano_miles","privacy":"Polityka prywatności","pwa.open":"Otwórz Stronę TurboWarp","scratchBugs":"Zgłoś błędy w Scratch","source":"Kod źródłowy","update.linux":"Jeśli zainstalowałeś TurboWarp Desktop ze sklepu z aplikacjami lub menedżera pakietów, takiego jak Snap Store, poczekaj, aż aktualizacja zostanie wypchnięta do sklepu. W przeciwnym razie uruchom nowy instalator poniżej.","update.mac":"Aby zaktualizować, pobierz i zainstaluj nową aplikację poniżej.","update.windows":"Aby zaktualizować, pobierz i uruchom nowy instalator poniżej.","win.32":"Alternatywne pobranie dla 32-bitowych systemów","win.download":"Pobierz dla Windowsa (64-bit)","win.help":"Jeżeli pojawi się alert Windows SmartScreen, kliknij „Więcej informacji”, a następnie „Uruchom mimo wszystko”."},
+  "pt":{"header.affiliation":"O TurboWarp não tem afiliação com o Scratch, a Equipe do Scratch ou a Fundação Scratch.","header.subtitle":"Use o {TurboWarp}, o mod do Scratch com um compilador, modo escuro, addons, e mais, em um app no seu computador. Até funciona sem internet.","linux.snapTitle":"Baixe pela Snap Store","picture.caption":"Projeto na imagem: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Projeto na imagem: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidade","source":"Código-fonte","update.linux":"Se você instalou o TurboWarp Desktop de uma loja de aplicativo ou administrador de pacote como a Snap Store, espere até a atualização ser publicada na loja. Senão, rode o novo instalador abaixo.","update.mac":"Para atualizar, baixe e execute o novo aplicativo abaixo.","update.windows":"Para atualizar, baixe e execute o novo instalador abaixo."},
+  "ro":{"header.affiliation":"TurboWarp nu este conectat cu Scratch, Echipa Scratch, sau Fundația Scratch."},
+  "ru":{"header.affiliation":"TurboWarp не связан с Scratch, Командой Scratch или Фондом Scratch .","header.subtitle":"Используйте {TurboWarp}, модификацию Scratch с компилятором, темным режимом, дополнения и многое другое из приложения на рабочем столе. Оно работает даже в офлайн-режиме.","linux.snapTitle":"Получите в Snap Store","picture.caption":"Изображённый проект: {project}","picture.caption.project":"Full Sphere Path Tracer от piano_miles","picture.title":"Изображённый проект: Full Sphere Path Tracer от piano_miles","privacy":"Политика конфиденциальности","source":"Исходный код","update.linux":"Если вы установили TurboWarp Desktop из магазина приложений или диспетчера пакетов, такого как Snap Store, дождитесь, пока обновление будет отправлено в магазин. В противном случае запустите новый установочный файл ниже.","update.mac":"Чтобы обновить, скачайте и установите приложение ниже.","update.windows":"Чтобы обновить, скачайте и запустите установочный файл ниже."},
+  "sl":{"header.affiliation":"TurboWarp ni povezan s Scratchem, skupino Scratch ali fundacijo Scratch.","header.subtitle":"Uporabljajte {TurboWarp}, spremenjeno različico Scratcha s prevajalnikom kode, temnim načinom, dodatki in drugimi funkcijami, kot aplikacijo na svojem računalniku. Deluje tudi brez internetne povezave.","linux.snapTitle":"Namestitev iz trgovine Snap Store","picture.caption":"Projekt na sliki: {project}","picture.caption.project":"Full Sphere Path Tracer avtorja piano_miles","picture.title":"Projekt na sliki: Full Sphere Path Tracer avtorja piano_miles","privacy":"Politika zasebnosti","source":"Izvirna koda","update.linux":"Če ste namestili TurboWarp Desktop s pomočjo trgovine z aplikacijami ali upravitelja paketov, kot je Snap Store, počakajte, dokler posodobitev ni na voljo v trgovini. Sicer zaženite nov namestitveni program spodaj.","update.mac":"Za posodobitev spodaj prenesite in namestite novo aplikacijo.","update.windows":"Za posodobitev spodaj prenesite nov namestitveni program."},
+  "sv":{"source":"Källkod"},
+  "tr":{"githubBugs":"Hataları GitHub'da bildir","header.affiliation":"TurboWarp, Scratch, Scratch Takım veya Scratch Vakıfı ile bağlantılı değildir.","header.subtitle":"{TurboWarp}'u kullan, bir derleyici olan Scratch modu, karanlık modu, eklentiler ve çevrimdışı olduğunuzda bile çalışır.","linux.anywhere":"Tüm dağıtımlarda çalışır.","linux.choices":"Linux kullanıcılarının bazı seçenekleri vardır.","linux.snapTitle":"Snap Storundan alın","linux.terminal":"Bunu bir terminalde çalıştır","linux.uninstall":"Kaldır","mac.download":"macOS için İndir (Evrensel)","mac.help":"Eğer bir Gatekeeper iletisi gözükürse, Finder'ı açın, Uygulamalar kısmına gidin, TurboWarp'a sağ tıklayın ve \"Aç\" tuşunu seçin, ardından tekrar \"Aç\" tuşuna basın.","picture.caption":"Fotoğrafta gösterilen proje: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"Fotoğrafta gösterilen proje: piano_miles tarafından Full Sphere Path Tracer","privacy":"Gizillik politikası","pwa.help":"Daha sonra URL'deki indir butonuna bas. Görünmesi birkaç saniye alabilir.","pwa.open":"TurboWarp Websitesi'ni Aç","scratchBugs":"Hataları Scratch'te bildir","source":"Kaynak kodu","update.linux":"Eğer Turbowarp Desktop'u bir uygulama mağazasından örneğin Snap Store indirirsen, güncelleme mağazaya aktarılana kadar bekleyin. Aksi takdirde, aşağıdaki yeni yükleyiciyi çalıştırın.","update.mac":"Güncellemek için, yeni yükleyiciği aşağıda indirin.","update.windows":"Güncellemek için, yeni yükleyiciği aşağıda çalıştır.","win.32":"32-bit sistemler için alternatif indirme","win.download":"Windows için İndir (64-bit)","win.help":"Eğer bir Windows SmartScreen uyarısı gözükürse, \"Daha fazla bilgi\" ve ardından \"Yine de çalıştır\" tuşlarına basınız."},
+  "zh-cn":{"header.affiliation":"TurboWarp 不属于 Scratch、Scratch 团队或 Scratch 基金会。","header.subtitle":"在你的电脑上使用 {TurboWarp}，一个拥有编译器、深色模式、插件等功能的 Scratch 修改版。它甚至还能在你离线的时候运行。","linux.snapTitle":"从 Snap Store 获取","picture.caption":"图片中的作品：{project}","picture.caption.project":"由 piano_miles 制作的 Full Sphere Path Tracer","picture.title":"图片中的作品：由 piano_miles 制作的 Full Sphere Path Tracer","privacy":"隐私政策","source":"源代码","update.linux":"如果你从像 Snap Store 一样的应用商店或包管理器安装了 TurboWarp Desktop，请等待更新推送到该商店。否则，请运行下面的新安装程序。","update.mac":"在下面下载并安装新的应用程序以更新。","update.windows":"在下面下载并运行新的安装程序以更新。"},
+  "zh-tw":{"header.affiliation":"TurboWarp 並不隸屬於 Scratch、Scratch 團隊或 Scratch 基金會。","header.subtitle":"{TurboWarp}，運行更快且帶有黑暗模式、附加元件及其他好用功能的 Scratch，可在電腦和手機上使用，離線亦然。","linux.snapTitle":"從 Snap Store 安裝","picture.caption":"上圖專案：{project}","picture.caption.project":"Full Sphere Path Tracer，作者：piano_miles","picture.title":"上圖專案：Full Sphere Path Tracer，作者：piano_miles","privacy":"隱私政策","source":"原始碼","update.linux":"若你是從應用商店或軟體套件管理系統（如 Snap Store）安裝 TurboWarp 的，就必須等到它放上更新。或者，運行下方的安裝程式。","update.mac":"下載並安裝新版程式以更新。","update.windows":"下載並運行下方的新版安裝程式以更新。"},
+  }/*===*/;
+
+          const translatableElements = document.querySelectorAll('[data-l10n]');
+          const translatableAttributes = document.querySelectorAll('[data-l10n-attrib]');
+
+          function getId(el) {
+            if (el.getAttribute('data-l10n-subkey')) return el.getAttribute('data-l10n-subkey');
+            return el.textContent.trim().replace(/\s+/g, '_').replace(/[^a-z_0-9]/gi, '') || ('placeholder' + j);
           }
 
-          for (const el of translatableAttributes) {
-            for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
+          function translate(language) {
+            if (!allLanguageMessages[language]) language = language.split('-')[0];
+            const messages = allLanguageMessages[language];
+            if (!messages) return;
+            document.documentElement.lang = language;
+
+            for (const el of translatableElements) {
+              const nodes = el.childNodes;
+              const namedNodes = {};
+              const key = el.getAttribute('data-l10n');
               const message = messages[key];
+
               if (!message) {
                 console.warn('Missing message: ' + key);
                 continue;
               }
-              el.setAttribute(attribute, message);
-            }
-          }
-        }
 
-        function genl10n() {
-          const result = {};
-          for (const el of translatableElements) {
-            const nodes = el.childNodes;
-            const key = el.getAttribute('data-l10n');
-
-            let translationString = '';
-            let textNodes = 0;
-            for (let i = 0; i < nodes.length; i++) {
-              const node = nodes[i];
-              let nodeText = node.textContent;
-              nodeText = nodeText.replace(/^\s+/, i === 0 ? '' : ' ');
-              nodeText = nodeText.replace(/\s+$/, i === nodes.length - 1 ? '' : ' ');
-              if (node.nodeName === '#text') {
-                translationString += nodeText;
-                textNodes++;
-              } else {
+              for (const node of nodes) {
+                if (node.nodeName === '#text') continue;
                 const id = getId(node);
-                translationString += '{' + id + '}';
-                if (node.getAttribute('data-notranslate') === null) {
-                  result[key + '.' + id] = nodeText;
+                namedNodes[id] = node;
+                const message = messages[key + '.' + id];
+                if (message) {
+                  node.textContent = message;
+                }
+              }
+
+              while (el.firstChild) el.removeChild(el.firstChild);
+
+              const messageParts = message.split(/{|}/g);
+              for (let i = 0; i < messageParts.length; i++) {
+                const part = messageParts[i];
+                if (i % 2 === 0) {
+                  el.appendChild(document.createTextNode(part));
+                } else {
+                  const node = namedNodes[part];
+                  if (!node) {
+                    console.warn('Missing named node: ' + part);
+                    continue;
+                  }
+                  el.appendChild(node);
                 }
               }
             }
-            if (result[key] && result[key] !== translationString) {
-              console.warn('Mismatch: ' + key);
-            }
-            result[key] = translationString;
-            if (textNodes === 0) {
-              console.warn('No text nodes: ' + key);
+
+            for (const el of translatableAttributes) {
+              for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
+                const message = messages[key];
+                if (!message) {
+                  console.warn('Missing message: ' + key);
+                  continue;
+                }
+                el.setAttribute(attribute, message);
+              }
             }
           }
 
-          for (const el of translatableAttributes) {
-            for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
-              const text = el.getAttribute(attribute);
-              if (result[key] && result[key] !== text) {
+          function genl10n() {
+            const result = {};
+            for (const el of translatableElements) {
+              const nodes = el.childNodes;
+              const key = el.getAttribute('data-l10n');
+
+              let translationString = '';
+              let textNodes = 0;
+              for (let i = 0; i < nodes.length; i++) {
+                const node = nodes[i];
+                let nodeText = node.textContent;
+                nodeText = nodeText.replace(/^\s+/, i === 0 ? '' : ' ');
+                nodeText = nodeText.replace(/\s+$/, i === nodes.length - 1 ? '' : ' ');
+                if (node.nodeName === '#text') {
+                  translationString += nodeText;
+                  textNodes++;
+                } else {
+                  const id = getId(node);
+                  translationString += '{' + id + '}';
+                  if (node.getAttribute('data-notranslate') === null) {
+                    result[key + '.' + id] = nodeText;
+                  }
+                }
+              }
+              if (result[key] && result[key] !== translationString) {
                 console.warn('Mismatch: ' + key);
               }
-              result[key] = text;
+              result[key] = translationString;
+              if (textNodes === 0) {
+                console.warn('No text nodes: ' + key);
+              }
+            }
+
+            for (const el of translatableAttributes) {
+              for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
+                const text = el.getAttribute(attribute);
+                if (result[key] && result[key] !== text) {
+                  console.warn('Mismatch: ' + key);
+                }
+                result[key] = text;
+              }
+            }
+
+            document.body.appendChild(Object.assign(document.createElement('a'), {
+              href: URL.createObjectURL(new Blob([JSON.stringify(result)])),
+              download: 'desktop-web.json'
+            })).click();
+
+            return result;
+          }
+
+          return {
+            translate,
+            genl10n
+          };
+        })();
+        L.translate(navigator.language.toLowerCase());
+      </script>
+      <script>
+        (function() {
+          var VERSION = '0.9.0';
+
+          function getOS() {
+            if (/android/i.test(navigator.userAgent)) return 'windows';
+            if (/iphone|ipad|ipod/i.test(navigator.userAgent)) return 'windows';
+            if (/linux/i.test(navigator.userAgent)) return 'linux';
+            if (/cros/i.test(navigator.userAgent)) return 'chrome';
+            if (/mac/i.test(navigator.userAgent)) return 'mac';
+            return 'windows';
+          }
+          function setOS(os) {
+            document.body.setAttribute('os', os);
+          }
+
+          document.querySelector('.os-button-windows').addEventListener('click', function () {
+            setOS('windows');
+          });
+          document.querySelector('.os-button-mac').addEventListener('click', function () {
+            setOS('mac');
+          });
+          document.querySelector('.os-button-linux').addEventListener('click', function () {
+            setOS('linux');
+          });
+          document.querySelector('.os-button-chrome').addEventListener('click', function () {
+            setOS('chrome');
+          });
+
+          var links = document.querySelectorAll('a[data-href]');
+          for (var i = 0; i < links.length; i++) {
+            links[i].href = links[i].getAttribute('data-href').replace(/{version}/g, VERSION);
+          }
+          var versionTexts = document.querySelectorAll('.version-text');
+          for (var i = 0; i < versionTexts.length; i++) {
+            versionTexts[i].textContent = versionTexts[i].textContent.replace(/{version}/g, VERSION);
+          }
+
+          var images = document.querySelectorAll('img[data-src]');
+          var observer = window.IntersectionObserver && new IntersectionObserver(function (entries) {
+            for (var i = 0; i < entries.length; i++) {
+              var entry = entries[i];
+              if (entry.isIntersecting && !entry.target.src) {
+                entry.target.src = entry.target.getAttribute('data-src');
+              }
+            }
+          }, {
+            rootMargin: '50px'
+          });
+          for (var i = 0; i < images.length; i++) {
+            if (observer) {
+              observer.observe(images[i]);
+            } else {
+              images[i].src = images[i].getAttribute('data-src');
             }
           }
 
-          document.body.appendChild(Object.assign(document.createElement('a'), {
-            href: URL.createObjectURL(new Blob([JSON.stringify(result)])),
-            download: 'desktop-web.json'
-          })).click();
-
-          return result;
-        }
-
-        return {
-          translate,
-          genl10n
-        };
-      })();
-      L.translate(navigator.language.toLowerCase());
-    </script>
-    <script>
-      (function() {
-        var VERSION = '0.9.0';
-
-        function getOS() {
-          if (/android/i.test(navigator.userAgent)) return 'windows';
-          if (/iphone|ipad|ipod/i.test(navigator.userAgent)) return 'windows';
-          if (/linux/i.test(navigator.userAgent)) return 'linux';
-          if (/cros/i.test(navigator.userAgent)) return 'chrome';
-          if (/mac/i.test(navigator.userAgent)) return 'mac';
-          return 'windows';
-        }
-        function setOS(os) {
-          document.body.setAttribute('os', os);
-        }
-
-        document.querySelector('.os-button-windows').addEventListener('click', function () {
-          setOS('windows');
-        });
-        document.querySelector('.os-button-mac').addEventListener('click', function () {
-          setOS('mac');
-        });
-        document.querySelector('.os-button-linux').addEventListener('click', function () {
-          setOS('linux');
-        });
-        document.querySelector('.os-button-chrome').addEventListener('click', function () {
-          setOS('chrome');
-        });
-
-        var links = document.querySelectorAll('a[data-href]');
-        for (var i = 0; i < links.length; i++) {
-          links[i].href = links[i].getAttribute('data-href').replace(/{version}/g, VERSION);
-        }
-        var versionTexts = document.querySelectorAll('.version-text');
-        for (var i = 0; i < versionTexts.length; i++) {
-          versionTexts[i].textContent = versionTexts[i].textContent.replace(/{version}/g, VERSION);
-        }
-
-        var images = document.querySelectorAll('img[data-src]');
-        var observer = window.IntersectionObserver && new IntersectionObserver(function (entries) {
-          for (var i = 0; i < entries.length; i++) {
-            var entry = entries[i];
-            if (entry.isIntersecting && !entry.target.src) {
-              entry.target.src = entry.target.getAttribute('data-src');
-            }
+          if (/from|to|changelog/i.test(location.search)) {
+            document.body.setAttribute('changelog', 'true');
+            document.getElementById('select-os').scrollIntoView();
           }
-        }, {
-          rootMargin: '50px'
-        });
-        for (var i = 0; i < images.length; i++) {
-          if (observer) {
-            observer.observe(images[i]);
-          } else {
-            images[i].src = images[i].getAttribute('data-src');
-          }
-        }
 
-        if (/from|to|changelog/i.test(location.search)) {
-          document.body.setAttribute('changelog', 'true');
-          document.getElementById('select-os').scrollIntoView();
-        }
-
-        setOS(getOS());
-        document.body.setAttribute('loaded', '');
-      }());
-    </script>
-  </body>
-</html>
+          setOS(getOS());
+          document.body.setAttribute('loaded', '');
+        }());
+      </script>
+    </body>
+  </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,789 +1,789 @@
-  <!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <title>TurboWarp Desktop</title>
-      <meta name="description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop.">
-      <meta name="theme-color" content="#ff4c4c">
-      <meta property="og:type" content="website" />
-      <meta property="og:title" content="TurboWarp Desktop" />
-      <meta property="og:description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop." />
-      <meta property="og:url" content="https://desktop.turbowarp.org/" />
-      <meta property="og:image" content="https://desktop.turbowarp.org/screenshot-light.png" />
-      <meta property="og:image:width" content="1280" />
-      <meta property="og:image:height" content="800" />
-      <meta name="twitter:card" content="summary_large_image" />
-      <style>
-        * {
-          box-sizing: border-box;
-        }
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TurboWarp Desktop</title>
+    <meta name="description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop.">
+    <meta name="theme-color" content="#ff4c4c">
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="TurboWarp Desktop" />
+    <meta property="og:description" content="TurboWarp Desktop lets you use TurboWarp, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop." />
+    <meta property="og:url" content="https://desktop.turbowarp.org/" />
+    <meta property="og:image" content="https://desktop.turbowarp.org/screenshot-light.png" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="800" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
 
-        body {
-          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-          margin: 0;
-          padding: 0;
-          font-size: 16px;
-          background-color: white;
-          color: black;
-        }
-        a {
-          color: #25d;
-          text-decoration: none;
-        }
-        a:hover {
-          text-decoration: underline;
-        }
-        a:active {
-          color: red;
-        }
-        img {
-          display: block;
-        }
-        section {
-          display: flex;
-          justify-content: center;
-          width: 100%;
-          padding-right: 8px;
-          padding-left: 8px;
-        }
-        body:not([loaded]) section:not(.visible-loading) {
-          visibility: hidden;
-        }
-        body:not([loaded]) .transparent-loading {
-          visibility: hidden;
-        }
-        section > div {
-          width: 100%;
-          max-width: 700px;
-        }
-        code, .code {
-          font-family: monospace;
-          font-size: 1rem;
-          padding: 3px;
-          background: #e6e6e6;
-          border-radius: 3px;
-        }
-        hr {
-          width: 100%;
-          height: 0;
-          border: none;
-          border-top: 1px dashed #aaa;
-        }
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+        font-size: 16px;
+        background-color: white;
+        color: black;
+      }
+      a {
+        color: #25d;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      a:active {
+        color: red;
+      }
+      img {
+        display: block;
+      }
+      section {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        padding-right: 8px;
+        padding-left: 8px;
+      }
+      body:not([loaded]) section:not(.visible-loading) {
+        visibility: hidden;
+      }
+      body:not([loaded]) .transparent-loading {
+        visibility: hidden;
+      }
+      section > div {
+        width: 100%;
+        max-width: 700px;
+      }
+      code, .code {
+        font-family: monospace;
+        font-size: 1rem;
+        padding: 3px;
+        background: #e6e6e6;
+        border-radius: 3px;
+      }
+      hr {
+        width: 100%;
+        height: 0;
+        border: none;
+        border-top: 1px dashed #aaa;
+      }
 
-        .header {
-          padding-top: 32px;
-          padding-bottom: 32px;
-          color: black;
-          background-color: #ff4c4c;
-          text-align: center;
-        }
+      .header {
+        padding-top: 32px;
+        padding-bottom: 32px;
+        color: black;
+        background-color: #ff4c4c;
+        text-align: center;
+      }
+      .header-title {
+        margin: 32px 0;
+        font-size: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: normal;
+      }
+      .header-title svg {
+        margin: 0 20px 0 0;
+        filter: drop-shadow(0 1px 8px rgba(0, 0, 0, 0.25));
+        width: 96px;
+        height: 96px;
+        min-width: 96px;
+        min-height: 96px;
+      }
+      @media (max-width: 400px) {
         .header-title {
-          margin: 32px 0;
-          font-size: 48px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-weight: normal;
+          flex-direction: column;
+          margin-top: 0;
         }
         .header-title svg {
-          margin: 0 20px 0 0;
-          filter: drop-shadow(0 1px 8px rgba(0, 0, 0, 0.25));
-          width: 96px;
-          height: 96px;
-          min-width: 96px;
-          min-height: 96px;
+          margin: 0 0 20px 0;
         }
-        @media (max-width: 400px) {
-          .header-title {
-            flex-direction: column;
-            margin-top: 0;
-          }
-          .header-title svg {
-            margin: 0 0 20px 0;
-          }
-        }
-        .header-subtitles > * {
-          margin-left: auto;
-          margin-right: auto;
-          max-width: 700px;
-        }
-        .header a {
-          color: inherit;
-          text-decoration: underline;
-        }
+      }
+      .header-subtitles > * {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 700px;
+      }
+      .header a {
+        color: inherit;
+        text-decoration: underline;
+      }
 
-        .changelog {
-          display: none;
-          margin-bottom: 32px;
-        }
-        [changelog="true"] .changelog {
-          display: flex;
-        }
-        .changelog li {
-          margin-top: 4px;
-        }
+      .changelog {
+        display: none;
+        margin-bottom: 32px;
+      }
+      [changelog="true"] .changelog {
+        display: flex;
+      }
+      .changelog li {
+        margin-top: 4px;
+      }
 
-        .select-os {
-          box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
-          background: white;
-          position: relative;
-          z-index: 99;
-          margin-bottom: 32px;
-        }
-        .select-os-inner {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          flex-wrap: wrap;
-          white-space: nowrap;
-        }
-        .select-os-buttons {
-          margin-top: 16px;
-          display: flex;
-          flex-direction: row;
-          flex-wrap: wrap;
-          justify-content: center;
-        }
-        .select-os-buttons button {
-          margin: 0 16px 16px 0;
-          border: 0;
-          cursor: pointer;
-          color: black;
-          font-size: .8rem;
-          font-weight: bold;
-          font-family: inherit;
-          border-radius: 26px;
-          background-color: rgba(0, 0, 0, 0.2);
-          padding: 8px 18px;
-          display: flex;
-          align-items: center;
-        }
-        .select-os-buttons button:last-child {
-          margin-right: 0;
-        }
-        .select-os-buttons button:hover {
-          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
-        }
-        .select-os-buttons button:active {
-          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
-        }
-        .os-button-icon {
-          margin-right: 5px;
-          width: 24px;
-          height: 24px;
-        }
-        [os="windows"] .os-button-windows,
-        [os="mac"] .os-button-mac,
-        [os="linux"] .os-button-linux,
-        [os="chrome"] .os-button-chrome {
-          background-color: #ff4c4c;
-          color: black;
-        }
+      .select-os {
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+        background: white;
+        position: relative;
+        z-index: 99;
+        margin-bottom: 32px;
+      }
+      .select-os-inner {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+        white-space: nowrap;
+      }
+      .select-os-buttons {
+        margin-top: 16px;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+      .select-os-buttons button {
+        margin: 0 16px 16px 0;
+        border: 0;
+        cursor: pointer;
+        color: black;
+        font-size: .8rem;
+        font-weight: bold;
+        font-family: inherit;
+        border-radius: 26px;
+        background-color: rgba(0, 0, 0, 0.2);
+        padding: 8px 18px;
+        display: flex;
+        align-items: center;
+      }
+      .select-os-buttons button:last-child {
+        margin-right: 0;
+      }
+      .select-os-buttons button:hover {
+        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+      }
+      .select-os-buttons button:active {
+        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
+      }
+      .os-button-icon {
+        margin-right: 5px;
+        width: 24px;
+        height: 24px;
+      }
+      [os="windows"] .os-button-windows,
+      [os="mac"] .os-button-mac,
+      [os="linux"] .os-button-linux,
+      [os="chrome"] .os-button-chrome {
+        background-color: #ff4c4c;
+        color: black;
+      }
 
-        .os {
-          margin-bottom: 32px;
-        }
-        body:not([os="windows"]) .os-windows,
-        body:not([os="mac"]) .os-mac,
-        body:not([os="linux"]) .os-linux,
-        body:not([os="chrome"]) .os-chrome {
-          display: none;
-        }
+      .os {
+        margin-bottom: 32px;
+      }
+      body:not([os="windows"]) .os-windows,
+      body:not([os="mac"]) .os-mac,
+      body:not([os="linux"]) .os-linux,
+      body:not([os="chrome"]) .os-chrome {
+        display: none;
+      }
 
-        .command::before {
-          content: "$ ";
-        }
+      .command::before {
+        content: "$ ";
+      }
 
-        .download-button-outer {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          text-align: center;
-        }
-        .download-button-inner {
-          display: flex;
-          align-items: center;
-          background-color: #ff4c4c;
-          color: black !important;
-          text-decoration: none !important;
-          padding: 12px 18px;
-          font-weight: bold;
-          border-radius: 5px;
-        }
-        .download-button-inner:hover {
-          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
-        }
-        .download-button-inner:active {
-          box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
-        }
-        .download-icon {
-          /* Icon from https://fontawesome.com/v5.15/icons/download?style=solid */
-          background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="black" d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"></path></svg>');
-          margin-right: 10px;
-          width: 16px;
-          height: 16px;
-          min-width: 16px;
-          min-height: 16px;
-        }
-        .install-help {
-          margin: 32px 0 0 0;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          text-align: center;
-        }
-        .install-help p {
-          margin: 0 0 16px 0;
-        }
+      .download-button-outer {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+      .download-button-inner {
+        display: flex;
+        align-items: center;
+        background-color: #ff4c4c;
+        color: black !important;
+        text-decoration: none !important;
+        padding: 12px 18px;
+        font-weight: bold;
+        border-radius: 5px;
+      }
+      .download-button-inner:hover {
+        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+      }
+      .download-button-inner:active {
+        box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8);
+      }
+      .download-icon {
+        /* Icon from https://fontawesome.com/v5.15/icons/download?style=solid */
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="black" d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"></path></svg>');
+        margin-right: 10px;
+        width: 16px;
+        height: 16px;
+        min-width: 16px;
+        min-height: 16px;
+      }
+      .install-help {
+        margin: 32px 0 0 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+      .install-help p {
+        margin: 0 0 16px 0;
+      }
 
-        .icon {
-          background-color: #ff4c4c;
-          color: black;
-          width: 32px;
-          height: 32px;
-          margin: 0 12px;
-          border-radius: 100%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        .icon svg {
-          width: 20px;
-          height: 20px;
-        }
-        .links {
-          margin-bottom: 32px;
-        }
+      .icon {
+        background-color: #ff4c4c;
+        color: black;
+        width: 32px;
+        height: 32px;
+        margin: 0 12px;
+        border-radius: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .icon svg {
+        width: 20px;
+        height: 20px;
+      }
+      .links {
+        margin-bottom: 32px;
+      }
+      .links-inner {
+        columns: 2;
+        column-gap: 0;
+      }
+      @media (max-width: 550px) {
         .links-inner {
-          columns: 2;
-          column-gap: 0;
+          columns: 1;
         }
-        @media (max-width: 550px) {
-          .links-inner {
-            columns: 1;
-          }
+      }
+      .link {
+        color: inherit;
+        display: flex;
+        align-items: center;
+        padding: 15px 0;
+        transition: .2s background-color;
+      }
+      .link:hover {
+        background-color: #eee;
+      }
+
+      .picture-container {
+        flex-direction: column;
+        text-align: center;
+        align-items: center;
+      }
+      .picture {
+        width: 100%;
+        height: 100%;
+        max-width: 1280px;
+      }
+      .picture-dark {
+        display: none;
+      }
+      .picture-caption {
+        padding-top: 4px;
+      }
+
+      .pwa-install {
+        width: 100%;
+        height: 100%;
+        max-width: 620px;
+      }
+
+      :focus-visible {
+        outline: 2px solid black;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #171717;
+          color: #eee;
         }
-        .link {
-          color: inherit;
-          display: flex;
-          align-items: center;
-          padding: 15px 0;
-          transition: .2s background-color;
+        a {
+          color: #4af;
+        }
+        code, .code {
+          background-color: #222;
+        }
+        a code {
+          color: #4af;
+        }
+        hr {
+          border-color: #333;
+        }
+        .select-os {
+          box-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
+          background: #1a1a1a;
+        }
+        .select-os-inner button {
+          color: white;
+          background-color: rgba(255, 255, 255, 0.2);
         }
         .link:hover {
-          background-color: #eee;
-        }
-
-        .picture-container {
-          flex-direction: column;
-          text-align: center;
-          align-items: center;
-        }
-        .picture {
-          width: 100%;
-          height: 100%;
-          max-width: 1280px;
+          background-color: #333;
         }
         .picture-dark {
+          display: block;
+        }
+        .picture-light {
           display: none;
         }
-        .picture-caption {
-          padding-top: 4px;
-        }
-
-        .pwa-install {
-          width: 100%;
-          height: 100%;
-          max-width: 620px;
-        }
-
         :focus-visible {
-          outline: 2px solid black;
+          outline: 2px solid white;
+        }
+      }
+    </style>
+  </head>
+
+  <!--
+    Some icons are from Font Awesome https://fontawesome.com/
+    For license information, visit https://creativecommons.org/licenses/by/4.0/
+    Icons have been minified by hand.
+  -->
+
+  <body os="">
+    <section class="header visible-loading">
+      <div>
+        <h1 class="header-title">
+          <svg aria-hidden="true" viewBox="0 0 1024 1024">
+            <path d="m64 174.86735v641.13265c0 35.34622 28.653776 64 64 64h113.30332c9.32935 0 18.19416 4.07135 24.27337 11.14807l67.26992 78.30776c12.15843 14.15343 29.88806 22.29614 48.54676 22.29614h261.21326c18.6587 0 36.38832-8.14271 48.54676-22.29614l67.26992-78.30776c6.07921-7.07672 14.94402-11.14807 24.27337-11.14807h113.30332c35.34622 0 64-28.65378 64-64v-654.84694c0-35.34622-28.65378-64-64-64-0.38091 0-0.76182 0.0034-1.14268 0.0102l-767.99999 13.71429c-34.89522 0.62313-62.85733 29.08902-62.85733 63.9898z" fill="#cc3c3c" fill-rule="evenodd"/>
+            <path d="m64 96v672c0 35.34622 28.653776 64 64 64h128.17394c9.97413 0 19.37789 4.65076 25.43168 12.5776l51.18313 67.01917c12.1076 15.85368 30.9151 25.1552 50.86336 25.1552h256.69578c19.94826 0 38.75576-9.30152 50.86336-25.1552l51.18312-67.01917c6.0538-7.92684 15.45756-12.5776 25.43169-12.5776h128.17394c35.34622 0 64-28.65378 64-64v-672c0-35.346224-28.65378-64-64-64h-768c-35.346224 0-64 28.653776-64 64z" fill="#ff4c4c" fill-rule="evenodd"/>
+            <path d="m96 96v672c0 17.67311 14.32689 32 32 32h128.17394c19.94827 0 38.75577 9.30152 50.86337 25.1552l51.18312 67.01917c6.0538 7.92684 15.45755 12.5776 25.43168 12.5776h256.69578c9.97413 0 19.37788-4.65076 25.43168-12.5776l51.18312-67.01917c12.1076-15.85368 30.9151-25.1552 50.86337-25.1552h128.17394c17.67311 0 32-14.32689 32-32v-672c0-17.673112-14.32689-32-32-32h-768c-17.67311 0-32 14.326888-32 32zm-32 0c0-35.346224 28.653776-64 64-64h768c35.34622 0 64 28.653776 64 64v672c0 35.34622-28.65378 64-64 64h-128.17394c-9.97413 0-19.37789 4.65076-25.43169 12.5776l-51.18312 67.01917c-12.1076 15.85368-30.9151 25.1552-50.86336 25.1552h-256.69578c-19.94826 0-38.75576-9.30152-50.86336-25.1552l-51.18313-67.01917c-6.05379-7.92684-15.45755-12.5776-25.43168-12.5776h-128.17394c-35.346224 0-64-28.65378-64-64z" fill="#fff" fill-opacity=".2"/>
+            <g transform="matrix(4.1943736,0,0,4.1943736,229.13567,171.21359)" fill="none" stroke="#fff" stroke-width="56.4093">
+              <path d="m108.34581 31.577677c-0.79395 3.473563-1.38942 7.244861-1.7864 11.313892-0.0992 1.091691 0 2.481117 0.29773 4.168276 0.29773 1.984893 0.4466 3.374319 0.4466 4.168276 0 2.580361-1.68716 3.870542-5.06147 3.870542-2.18339 0-3.622435-0.64509-4.317148-1.935271-0.09925-2.183383-0.04962-5.160723 0.14887-8.93202 0.198487-4.46601 0.29773-7.44335 0.29773-8.93202-0.09924 0-0.248107-0.09924-0.4466-0.297734-9.229753 0.396979-17.91366 0.992447-26.05172 1.786404-0.198493 1.290181-0.198493 2.878095 0 4.763744l0.59546 5.359212c-0.396973 3.076585-0.59546 7.64184-0.59546 13.695765 0.297733 2.580361 0.4466 13.646143 0.4466 33.197344v10.867303c0 1.68716 0.24811 2.8781 0.74433 3.57281h9.22976c3.771293-0.49623 5.65694 1.09169 5.65694 4.76374 0 2.18339-1.042067 3.72168-3.1262 4.61488-1.290187 0.49623-3.572817 0.59547-6.84789 0.29774-1.984893-0.19849-4.317143-0.24812-6.99675-0.14887-3.672053 0.49622-8.138063 0.8932-13.39803 1.19093-5.359207 0.29774-8.634279-0.44659-9.825218-2.233-0.793957-1.19093-0.793957-2.43149 0-3.72168 1.389425-2.18338 5.011855-3.27507 10.867288-3.27507 3.076587 0 4.61488-0.84358 4.61488-2.53074 0-0.8932-0.04962-1.73678-0.14887-2.53074 0-2.48113 0.04962-4.66452 0.14887-6.550163 0.297733-5.359213 0.297733-12.901808 0-22.627784-0.39698-14.092743-0.248113-26.746439 0.4466-37.961086l-0.4466-0.446601c-3.076587 0.198489-8.832777 0.148867-17.268572-0.148867-0.396979 0-3.423941 0.198489-9.080887 0.595468 1.389425 9.527488 2.183383 16.325748 2.381872 20.394779l-0.297734 4.01941c-0.09924 1.48867-1.339803 2.233005-3.721676 2.233005-1.885649 0-3.473563-3.572808-4.763744-10.718425-0.595468-4.267521-1.190936-8.584664-1.786404-12.951429 0-0.694713-0.347356-1.885649-1.042069-3.572808-0.595468-1.786404-1.908676-4.750966-1.908676-5.644168 0-3.141175 2.901123-2.39465 6.67242-2.990118 0.297734 0 0.793957 0.04962 1.48867 0.148867 0.694713 0.09924 1.190936 0.148867 1.48867 0.148867h36.91902c9.130507-0.396979 17.96328-1.190936 26.49832-2.381872 0.595473-0.297734 1.488678-0.595468 2.679608-0.893202 2.08414-0.19849 3.87054 0.297733 5.35921 1.48867 1.48867 1.091691 1.9849 2.679606 1.48867 4.763744z" fill="none" stroke="#fff" stroke-width="56.4093"/>
+            </g>
+            <g transform="matrix(3.852509,0,0,3.852509,257.89982,219.83848)" fill="none" stroke="#ff4c4c" stroke-width="30.7075">
+              <path d="m110.38498 21.776581q-1.29661 5.672702-1.94492 12.317866-0.16208 1.782849 0.32415 4.538161 0.48623 3.241544 0.48623 4.538161 0 4.214007-5.51062 4.214007-3.5657 0-4.700239-2.107004-0.16208-3.565698 0.16208-9.72463 0.32415-7.293474 0.32415-9.724631-0.16207 0-0.48623-0.324155-15.073176 0.648309-28.3635 1.944927-0.324161 2.107003 0 5.186469l0.6483 5.834779q-0.6483 5.024392-0.6483 14.911102 0.48623 4.214006 0.48623 36.143214v11.831633q0 2.75531 0.81038 3.88985h10.048792q6.158927-0.81039 6.158927 5.18647 0 3.5657-3.403614 5.0244-2.107013 0.81039-7.455559 0.32416-3.241543-0.32416-7.617628-0.16208-5.996857 0.81038-14.586946 1.29661-8.75216 0.48624-10.69709-2.43115-1.296617-1.94493 0-4.05194 2.26908-3.56569 11.831631-3.56569 5.024396 0 5.024396-2.75532 0-1.45869-0.162081-2.75531 0-4.051935 0.162081-7.131398 0.48623-8.75217 0-24.635731-0.648311-23.014961 0.48623-41.329683l-0.48623-0.486231q-5.024396 0.324154-18.800953-0.162077-0.648309 0-9.886708 0.648308 2.26908 15.55941 2.593235 22.204574 0 0-0.324155 4.376085-0.162077 2.431158-4.05193 2.431158-3.079467 0-5.18647-11.669558-0.972463-6.969319-1.944926-14.100715 0-1.13454-1.134541-3.889852-0.972463-2.91739-0.972463-4.376084 0-4.05193 6.158933-5.024393 0.486232 0 1.620772 0.162077 1.13454 0.162078 1.620772 0.162078h16.856029q23.339116 0 23.339116 0 14.911096-0.648309 28.849729-2.593235 0.97247-0.486232 2.91739-0.972463 3.40363-0.324156 5.83478 1.620771 2.43116 1.782849 1.62077 5.18647z" fill="none" stroke="#ff4c4c" stroke-width="30.7075"/>
+            </g>
+            <g transform="matrix(4.1943736,0,0,4.1943736,228.25358,197.35677)" fill="#fff">
+              <path d="m108.34581 25.3789q-1.19093 5.210345-1.7864 11.313892-0.14887 1.637537 0.29773 4.168276 0.4466 2.97734 0.4466 4.168276 0 3.870542-5.06147 3.870542-3.275078 0-4.317148-1.935271-0.14887-3.275074 0.14887-8.93202 0.29773-6.699015 0.29773-8.93202-0.14886 0-0.4466-0.297734-13.84463 0.595468-26.05172 1.786404-0.29774 1.935271 0 4.763744l0.59546 5.359212q-0.59546 4.614877-0.59546 13.695765 0.4466 3.870542 0.4466 33.197344v10.86729q0 2.53074 0.74433 3.57281h9.22976q5.65694-0.74434 5.65694 4.76374 0 3.27508-3.1262 4.61488-1.93528 0.74434-6.84789 0.29774-2.97734-0.29774-6.99675-0.14887-5.50808 0.74433-13.39803 1.19093-8.03881 0.44661-9.825218-2.233-1.190936-1.7864 0-3.72168 2.084138-3.27507 10.867288-3.27507 4.61488 0 4.61488-2.53074 0-1.3398-0.14887-2.53074 0-3.72168 0.14887-6.55015 0.4466-8.03882 0-22.627784-0.59547-21.139115 0.4466-37.961086l-0.4466-0.446601q-4.61488 0.297734-17.268572-0.148867-0.595468 0-9.080887 0.595468 2.084138 14.291232 2.381872 20.394779 0 0-0.297734 4.01941-0.148867 2.233005-3.721676 2.233005-2.828473 0-4.763744-10.718425-0.893202-6.401281-1.786404-12.951429 0-1.042069-1.042069-3.572808-0.893202-2.679606-0.893202-4.019409 0-3.721675 5.656946-4.614877 0.446601 0 1.48867 0.148867t1.48867 0.148867h15.48217q21.43685 0 21.43685 0 13.69576-0.595468 26.49832-2.381872 0.89321-0.446601 2.679608-0.893202 3.12621-0.297735 5.35921 1.48867 2.23301 1.637537 1.48867 4.763744z" fill="#fff"/>
+            </g>
+          </svg>
+          <div>TurboWarp Desktop</div>
+        </h1>
+        <div class="header-subtitles">
+          <noscript><p>This page requires JavaScript.</p></noscript>
+          <p data-l10n="header.subtitle" class="transparent-loading">Use <a href="https://turbowarp.org" data-notranslate>TurboWarp</a>, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop. It even works when you're offline!</p>
+          <p class="transparent-loading"><i data-l10n="header.affiliation">TurboWarp is not affiliated with Scratch, the Scratch Team, or the Scratch Foundation.</i></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="select-os" id="select-os">
+      <div class="select-os-inner">
+        <div class="select-os-buttons">
+          <button class="os-button-windows">
+            <!-- Icon from https://fontawesome.com/icons/windows?style=brands -->
+            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"></path></svg>
+            <div>
+              Windows
+            </div>
+          </button>
+          <button class="os-button-mac">
+            <!-- Icon from https://fontawesome.com/icons/apple?style=brands -->
+            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"></path></svg>
+            <div>
+              macOS
+            </div>
+          </button>
+          <button class="os-button-linux">
+            <!-- Icon from https://fontawesome.com/icons/linux?style=brands -->
+            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-6.5 5.8-11.4 14.7-16.6 20.2-4.2 4.3-10.3 5.9-17 8.3s-14 6-18.5 14.5c-2.1 3.9-2.8 8.1-2.8 12.4 0 3.9.6 7.9 1.2 11.8 1.2 8.1 2.5 15.7.8 20.8-5.2 14.4-5.9 24.4-2.2 31.7 3.8 7.3 11.4 10.5 20.1 12.3 17.3 3.6 40.8 2.7 59.3 12.5 19.8 10.4 39.9 14.1 55.9 10.4 11.6-2.6 21.1-9.6 25.9-20.2 12.5-.1 26.3-5.4 48.3-6.6 14.9-1.2 33.6 5.3 55.1 4.1.6 2.3 1.4 4.6 2.5 6.7v.1c8.3 16.7 23.8 24.3 40.3 23 16.6-1.3 34.1-11 48.3-27.9 13.6-16.4 36-23.2 50.9-32.2 7.4-4.5 13.4-10.1 13.9-18.3.4-8.2-4.4-17.3-15.5-29.7zM223.7 87.3c9.8-22.2 34.2-21.8 44-.4 6.5 14.2 3.6 30.9-4.3 40.4-1.6-.8-5.9-2.6-12.6-4.9 1.1-1.2 3.1-2.7 3.9-4.6 4.8-11.8-.2-27-9.1-27.3-7.3-.5-13.9 10.8-11.8 23-4.1-2-9.4-3.5-13-4.4-1-6.9-.3-14.6 2.9-21.8zM183 75.8c10.1 0 20.8 14.2 19.1 33.5-3.5 1-7.1 2.5-10.2 4.6 1.2-8.9-3.3-20.1-9.6-19.6-8.4.7-9.8 21.2-1.8 28.1 1 .8 1.9-.2-5.9 5.5-15.6-14.6-10.5-52.1 8.4-52.1zm-13.6 60.7c6.2-4.6 13.6-10 14.1-10.5 4.7-4.4 13.5-14.2 27.9-14.2 7.1 0 15.6 2.3 25.9 8.9 6.3 4.1 11.3 4.4 22.6 9.3 8.4 3.5 13.7 9.7 10.5 18.2-2.6 7.1-11 14.4-22.7 18.1-11.1 3.6-19.8 16-38.2 14.9-3.9-.2-7-1-9.6-2.1-8-3.5-12.2-10.4-20-15-8.6-4.8-13.2-10.4-14.7-15.3-1.4-4.9 0-9 4.2-12.3zm3.3 334c-2.7 35.1-43.9 34.4-75.3 18-29.9-15.8-68.6-6.5-76.5-21.9-2.4-4.7-2.4-12.7 2.6-26.4v-.2c2.4-7.6.6-16-.6-23.9-1.2-7.8-1.8-15 .9-20 3.5-6.7 8.5-9.1 14.8-11.3 10.3-3.7 11.8-3.4 19.6-9.9 5.5-5.7 9.5-12.9 14.3-18 5.1-5.5 10-8.1 17.7-6.9 8.1 1.2 15.1 6.8 21.9 16l19.6 35.6c9.5 19.9 43.1 48.4 41 68.9zm-1.4-25.9c-4.1-6.6-9.6-13.6-14.4-19.6 7.1 0 14.2-2.2 16.7-8.9 2.3-6.2 0-14.9-7.4-24.9-13.5-18.2-38.3-32.5-38.3-32.5-13.5-8.4-21.1-18.7-24.6-29.9s-3-23.3-.3-35.2c5.2-22.9 18.6-45.2 27.2-59.2 2.3-1.7.8 3.2-8.7 20.8-8.5 16.1-24.4 53.3-2.6 82.4.6-20.7 5.5-41.8 13.8-61.5 12-27.4 37.3-74.9 39.3-112.7 1.1.8 4.6 3.2 6.2 4.1 4.6 2.7 8.1 6.7 12.6 10.3 12.4 10 28.5 9.2 42.4 1.2 6.2-3.5 11.2-7.5 15.9-9 9.9-3.1 17.8-8.6 22.3-15 7.7 30.4 25.7 74.3 37.2 95.7 6.1 11.4 18.3 35.5 23.6 64.6 3.3-.1 7 .4 10.9 1.4 13.8-35.7-11.7-74.2-23.3-84.9-4.7-4.6-4.9-6.6-2.6-6.5 12.6 11.2 29.2 33.7 35.2 59 2.8 11.6 3.3 23.7.4 35.7 16.4 6.8 35.9 17.9 30.7 34.8-2.2-.1-3.2 0-4.2 0 3.2-10.1-3.9-17.6-22.8-26.1-19.6-8.6-36-8.6-38.3 12.5-12.1 4.2-18.3 14.7-21.4 27.3-2.8 11.2-3.6 24.7-4.4 39.9-.5 7.7-3.6 18-6.8 29-32.1 22.9-76.7 32.9-114.3 7.2zm257.4-11.5c-.9 16.8-41.2 19.9-63.2 46.5-13.2 15.7-29.4 24.4-43.6 25.5s-26.5-4.8-33.7-19.3c-4.7-11.1-2.4-23.1 1.1-36.3 3.7-14.2 9.2-28.8 9.9-40.6.8-15.2 1.7-28.5 4.2-38.7 2.6-10.3 6.6-17.2 13.7-21.1.3-.2.7-.3 1-.5.8 13.2 7.3 26.6 18.8 29.5 12.6 3.3 30.7-7.5 38.4-16.3 9-.3 15.7-.9 22.6 5.1 9.9 8.5 7.1 30.3 17.1 41.6 10.6 11.6 14 19.5 13.7 24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4s5.9-6.3 3.1-6.6-2.6 2.6-6 5.1c-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2s-18.7-4.8-24.9-9.7c-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z"></path></svg>
+            <div>
+              Linux
+            </div>
+          </button>
+          <button class="os-button-chrome">
+            <!-- Icon from https://fontawesome.com/v5.15/icons/chrome?style=brands -->
+            <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 496 512"><path fill="currentColor" d="M131.5 217.5L55.1 100.1c47.6-59.2 119-91.8 192-92.1 42.3-.3 85.5 10.5 124.8 33.2 43.4 25.2 76.4 61.4 97.4 103L264 133.4c-58.1-3.4-113.4 29.3-132.5 84.1zm32.9 38.5c0 46.2 37.4 83.6 83.6 83.6s83.6-37.4 83.6-83.6-37.4-83.6-83.6-83.6-83.6 37.3-83.6 83.6zm314.9-89.2L339.6 174c37.9 44.3 38.5 108.2 6.6 157.2L234.1 503.6c46.5 2.5 94.4-7.7 137.8-32.9 107.4-62 150.9-192 107.4-303.9zM133.7 303.6L40.4 120.1C14.9 159.1 0 205.9 0 256c0 124 90.8 226.7 209.5 244.9l63.7-124.8c-57.6 10.8-113.2-20.8-139.5-72.5z"></path></svg>
+            <div>
+              Chrome
+            </div>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="changelog">
+      <div>
+        <h2>Changes from v0.8.1 to v0.9.0</h2>
+        <ul>
+          <li>New addon: Paint costume by default</li>
+          <li>New addon: Hide delete button</li>
+          <li>New addon: Do not automatically space overlapping scripts</li>
+          <li class="os-windows">Windows: We now support 32-bit systems</li>
+          <li>You can now create cloud variables. However, they won't actually work unless uploaded to Scratch or a tool such as the TurboWarp Packager</li>
+          <li>Various bug fixes</li>
+          <li>Updated translations</li>
+        </ul>
+        <p class="os-windows" data-l10n="update.windows">To update, download and run the new installer below.</p>
+        <p class="os-mac" data-l10n="update.mac">To update, download and install the new app below.</p>
+        <p class="os-linux" data-l10n="update.linux">If you installed TurboWarp Desktop from an app store or package manager such as the Snap Store, wait until the update is pushed to the store. Otherwise, run the new installer below.</p>
+      </div>
+    </section>
+
+    <section class="os os-windows">
+      <div>
+        <div class="download-button-outer">
+          <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-x64.exe">
+            <div class="download-icon"></div>
+            <div data-l10n="win.download">Download for Windows (64-bit)</div>
+          </a>
+        </div>
+        
+        &nbsp;
+
+        <div class="download-button-outer">
+          <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-ia32.exe">
+            <div class="download-icon"></div>
+            <div data-l10n="win.download">Download for Windows (32-bit)</div>
+          </a>
+        </div>
+        
+        <div class="install-help">
+          <p data-l10n="win.help">If a Windows SmartScreen alert appears, click "More info" then "Run anyways".</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="os os-mac">
+      <div>
+        <div class="download-button-outer">
+          <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}.dmg">
+            <div class="download-icon"></div>
+            <div data-l10n="mac.download">Download for macOS (Universal)</div>
+          </a>
+        </div>
+
+        <div class="install-help">
+          <div data-l10n="mac.help">If a Gatekeeper prompt appears, open Finder, navigate to Applications, right click TurboWarp and select "Open" and then "Open" again.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="os os-linux">
+      <div>
+        <p data-l10n="linux.choices">Linux users have some choices.</p>
+        <hr>
+
+        <h2 data-l10n="linux.terminal">Run this in a terminal</h2>
+        <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/install.sh)"</code></p>
+        <p data-l10n="linux.anywhere">Works on any distribution.</p>
+        <hr>
+
+        <h2>Snap Store</h2>
+        <p>
+          <a href="https://snapcraft.io/turbowarp-desktop">
+            <!-- Image from https://github.com/snapcore/snap-store-badges -->
+            <img data-src="snap-store.png" width="182" height="56" alt="Get it from the Snap Store" title="Get it from the Snap Store" data-l10n-attrib="alt=linux.snapTitle,title=linux.snapTitle" style="display: inline;">
+          </a>
+        </p>
+        <hr>
+
+        <h2>Debian, Ubuntu, Raspberry Pi OS, etc.:</h2>
+        <ul>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-amd64-{version}.deb">x86 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.deb">x86 32-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.deb">ARM 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.deb">ARMv7l</a></li>
+        </ul>
+        <hr>
+
+        <h2>AppImage</h2>
+        <ul>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x86_64-{version}.AppImage">x86 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.AppImage">x86 32-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.AppImage">ARM 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.AppImage">ARMv7l</a></li>
+        </ul>
+        <hr>
+
+        <h2>Tarball</h2>
+        <ul>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x64-{version}.tar.gz">x86 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-ia32-{version}.tar.gz">x86 32-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.tar.gz">ARM 64-bit</a></li>
+          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.tar.gz">ARMv7l</a></li>
+        </ul>
+        <hr>
+
+        <h2 data-l10n="linux.uninstall">Uninstall</h2>
+        <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/uninstall.sh)"</code></p>
+      </div>
+    </section>
+
+    <section class="os os-chrome">
+      <div>
+        <div class="download-button-outer">
+          <a class="download-button-inner" href="https://turbowarp.org/" target="_blank" rel="noopener">
+            <div data-l10n="pwa.open">Open the TurboWarp Website</div>
+          </a>
+        </div>
+
+        <div class="install-help">
+          <p data-l10n="pwa.help">Then press the install button in the URL. It may take a few seconds to appear.</p>
+          <img data-src="pwa-install.png" width="620" height="258"class="pwa-install">
+        </div>
+      </div>
+    </section>
+
+    <section class="links">
+      <div class="links-inner">
+        <a class="link" href="https://github.com/TurboWarp/desktop/">
+          <div class="icon">
+            <!-- Icon from https://fontawesome.com/v5.15/icons/code?style=solid -->
+            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg>
+          </div>
+          <div data-l10n="source">Source code</div>
+        </a>
+        <a class="link" href="privacy.html">
+          <div class="icon">
+            <!-- Icon from https://fontawesome.com/v5.15/icons/file?style=solid -->
+            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg>
+          </div>
+          <div data-l10n="privacy">Privacy policy</div>
+        </a>
+        <a class="link" href="https://scratch.mit.edu/users/GarboMuffin/#comments">
+          <div class="icon">
+            <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
+            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
+          </div>
+          <div data-l10n="scratchBugs">Report bugs on Scratch</div>
+        </a>
+        <a class="link" href="https://github.com/TurboWarp/desktop/issues">
+          <div class="icon">
+            <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
+            <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
+          </div>
+          <div data-l10n="githubBugs">Report bugs on GitHub</div>
+        </a>
+      </div>
+    </section>
+
+    <section class="picture-container">
+      <img class="picture picture-light" data-src="screenshot-light.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
+      <img class="picture picture-dark" data-src="screenshot-dark.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
+      <p class="picture-caption" data-l10n="picture.caption">Project pictured: <a href="https://scratch.mit.edu/projects/425020125/" data-l10n-subkey="project">Full Sphere Path Tracer by piano_miles</a></p>
+    </section>
+
+    <script>
+      window.L = (function () {
+        const allLanguageMessages = /*===*/{
+"de":{"header.affiliation":"TurboWarp ist nicht mit Scratch, dem Scratch Team oder der Scratch-Stiftung verbunden.","header.subtitle":"Verwende {TurboWarp}, das Scratch-Mod mit einem Compiler, Dunkelmodus, Addons und mehr, mit einer App auf deinem Desktop. Es funktioniert auch, wenn du offline bist.","linux.snapTitle":"Vom Snap-Store holen","picture.caption":"Abgebildetes Projekt: {project}","picture.caption.project":"Full Sphere Path Tracer von piano_miles","picture.title":"Angezeigtes Projekt: Full Sphere Path Tracer von piano_miles","privacy":"Datenschutzerklärung","source":"Quellcode","update.linux":"Falls du TurboWarp Desktop von einem App-Store oder Paketmanager wie dem Snap-Store installiert hast, warte bis das Update im Store verfügbar ist. Ansonsten kannst du unten den neuen Installer ausführen","update.mac":"Lade die neue App herunter und führe sie aus, um TurboWarp zu aktualisieren.","update.windows":"Lade den Installer herunter und führe ihn aus, um TurboWarp zu aktualisieren."},
+"es":{"header.affiliation":"TurboWarp no está afiliado con Scratch, el equipo de Scratch o la Scratch Foundation.","header.subtitle":"Use {TurboWarp}, el mod de Scratch con compilador, modo oscuro, addons y más, desde una app en su escritorio. Funciona incluso sin una conexión a internet.","linux.snapTitle":"Obtener en la Snap Store","picture.caption":"Proyecto en imagen: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Proyecto en la imagen: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidad","source":"Código fuente","update.linux":"Si instaló TurboWarp Desktop desde una tienda de aplicaciones o administrador de paquetes, por ejemplo la Snap Store, espere hasta que la actualización se publique en la tienda. De lo contrario, ejecute el nuevo instalador debajo.","update.mac":"Para actualizar, descargue e instale la app debajo.","update.windows":"Para actualizar, descargue y ejecute el instalador debajo."},
+"fr":{"githubBugs":"Rapporter des bugs sur GitHub","header.affiliation":"TurboWarp n'est pas affilié à Scratch, à l'équipe Scratch ou à la Fondation Scratch.","header.subtitle":"Utilisez {TurboWarp}, le mod Scratch avec un compilateur, un mode sombre, des modules complémentaires et plus encore, à partir d'une application sur votre bureau. Cela fonctionne même lorsque vous êtes hors ligne.","linux.choices":"Les utilisateurs de Linux ont du choix.","linux.terminal":"Lancer dans une console","linux.uninstall":"Désinstaller","mac.download":"Télécharger pour macOS (universel)","privacy":"Politique de Confidentialité","pwa.help":"Appuyez sur le bouton d'installation à l'aide de l'URL. Cela peut prendre quelques secondes à apparaître.","pwa.open":"Ouvrir le site de TurboWarp","scratchBugs":"Rapporter des bugs sur Scratch","source":"Code source","update.linux":"Si vous avez installé TurboWarp Desktop à partir d'un magasin d'applications ou d'un gestionnaire de packages tel que Snap Store, attendez que la mise à jour soit envoyée au magasin. Sinon, exécutez le nouveau programme d'installation ci-dessous.","update.mac":"Pour mettre à jour, téléchargez et installez la nouvelle application ci-dessous.","update.windows":"Pour mettre à jour, téléchargez et exécutez le nouveau programme d'installation ci-dessous.","win.32":"Télécharger pour des systèmes 32-bit","win.download":"Télécharger pour Windows (64-bit)"},
+"it":{"githubBugs":"Notifica i bug su GitHub","header.affiliation":"TurboWarp non è affiliato a Scratch, allo Scratch Team o alla Scratch Foundation.","header.subtitle":"Usa {TurboWarp}, la mod di Scratch dotata di compilatore, dark mode, addon e molto altro come app sul tuo PC. Funziona anche quando non sei online.","linux.anywhere":"Funziona per qualunque distribuzione.","linux.choices":"Gli utenti Linux hanno alcune possibili scelte.","linux.snapTitle":"Ottienilo dallo Snap Store","linux.terminal":"Esegui questo comando in una finestra di Terminale","linux.uninstall":"Disinstalla","mac.download":"Scarica per macOS (Universale)","mac.help":"Se appare un avviso di Gatekeeper apri il Finder, vai ad Applicazioni, clicca TurboWarp con il tasto destro e poi seleziona \"Apri\" e di nuovo \"Apri\".","picture.caption":"Progetto mostrato: {project}","picture.caption.project":"Full Sphere Path Tracer di piano_miles","picture.title":"Progetto: Full Sphere Path Tracer di piano_miles","privacy":"Politica delle privacy","pwa.help":"Premi il pulsante di installazione nella barra dell'indirizzo. Potrebbero essere necessari alcuni secondi prima che appaia.","pwa.open":"Apri il sito TurboWarp","scratchBugs":"Notifica i bug su Scratch","source":"Codice sorgente","update.linux":"Se hai installato TurboWarp Desktop da un app store o usando un gestore di pacchetti come Snap Store attendi fino a che l'aggiornamento è presente nello store. In alternativa puoi eseguire il nuovo installatore che trovi qui sotto.","update.mac":"Per aggiornare, scaricare ed eseguire la nuova app qui sotto.","update.windows":"Per aggiornare, scaricare ed eseguire il nuovo installatore qui sotto.","win.32":"Download alternativi per sistemi a 32-bit:","win.download":"Scarica per Windows (64-bit)","win.help":"Se compare un avviso di Windows, clicca \"More info\" e poi \"Run anyways\""},
+"ja":{"header.affiliation":"TurboWarpはScratch、Scratch Team、Scratch財団と提携していません。","header.subtitle":"コンパイラ、ダークモード、アドオンなどを備えたScratch MOD の{TurboWarp}をデスクトップ上で利用できます。オフラインでも動作します。","linux.snapTitle":"Snap Store で入手できます","picture.caption":"写真のプロジェクト: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"プロジェクトの写真: Full Sphere Path Tracer by piano_miles","privacy":"プライバシーポリシー","source":"ソースコード","update.linux":"アプリストアまたはSnapStoreなどのパッケージマネージャからTurboWarp Desktopをインストールした場合は、アップデートがストアに入るされるまで待って下さい。それ以外の場合は、以下の新規インストーラーを実行してください。","update.mac":"アップデートするには、以下の新しいアプリをダウンロードしてインストールしてください。","update.windows":"更新するには、以下の新しいインストーラーをダウンロードして実行します。"},
+"ko":{"header.affiliation":"TurboWarp는 스크래치, 스크래치 팀,  스크래치 재단에 소속되지 않았습니다.","header.subtitle":"{TurboWarp}를 이용하여 오프라인일 때에도 당신의 컴퓨터에서 스크래치를 다크 모드, 컴파일러, 애드온과 같은 기능을 사용해 보세요.","linux.snapTitle":"Snap Store에서 받기","picture.caption":"프로젝트 캡쳐됨: {project}","picture.caption.project":"piano_miles의 \"Full Sphere Path Tracer\"","picture.title":"piano_miles의 \"Full Sphere Path Tracer\" 프로젝트의 캡쳐","privacy":"개인정보 보호 정책","source":"소스코드","update.linux":"SnapStore와 같은 앱 스토어 또는 패키지 관리자에서 TurboWarp 데스크탑을 설치한 경우 업데이트가 스토어에 올라올 때까지 기다립니다. 그렇지 않은 경우 아래에서 새 설치 프로그램을 실행하세요.","update.mac":"업데이트하려면, 아래의 새 앱을 다운로드하고 설치하세요.","update.windows":"업데이트하려면, 아래의 새 설치기를 다운로드하고 실행하세요."},
+"nb":{"header.affiliation":"TurboWarp er ikke tilknyttet Scratch, Scratch-gruppen eller Scratch Foundation.","header.subtitle":"Bruk {TurboWarp}, Scratch-modet med kompilator, mørkt tema, utvidelser og mer, fra en app på din PC. Det fungerer også når du er offline."},
+"pl":{"githubBugs":"Zgłoś błędy na GitHub","header.affiliation":"TurboWarp nie jest powiązany ze Scratch, Scratch Team, ani Scratch Foundation.","header.subtitle":"Używaj {TurboWarp}, mod Scratcha z kompilatorem, trybem ciemnym, dodatkami i nie tylko. Z aplikacji na pulpicie. Działa nawet, gdy jesteś offline.","linux.snapTitle":"Pobierz go ze sklepu Snap ","linux.terminal":"Uruchom to w terminalu","linux.uninstall":"Oinstaluj","mac.download":"Pobierz dla macOS (Uniwersalny)","mac.help":"Jeżeli pojawi się informacja Gatekeeper, otwórz Finder, przejdź do Aplikacji, prawym przyciskiem kliknij TurboWarp i wybierz \"Otwórz\" i \"Otwórz\" jeszcze raz.","picture.caption":"Projekt na zdjęciu: {project}","picture.caption.project":"Full Sphere Path Tracer autorstwa piano_miles","picture.title":"Pokazany projekt: Full Sphere Path Tracer autorstwa piano_miles","privacy":"Polityka prywatności","pwa.open":"Otwórz Stronę TurboWarp","scratchBugs":"Zgłoś błędy w Scratch","source":"Kod źródłowy","update.linux":"Jeśli zainstalowałeś TurboWarp Desktop ze sklepu z aplikacjami lub menedżera pakietów, takiego jak Snap Store, poczekaj, aż aktualizacja zostanie wypchnięta do sklepu. W przeciwnym razie uruchom nowy instalator poniżej.","update.mac":"Aby zaktualizować, pobierz i zainstaluj nową aplikację poniżej.","update.windows":"Aby zaktualizować, pobierz i uruchom nowy instalator poniżej.","win.32":"Alternatywne pobranie dla 32-bitowych systemów","win.download":"Pobierz dla Windowsa (64-bit)","win.help":"Jeżeli pojawi się alert Windows SmartScreen, kliknij „Więcej informacji”, a następnie „Uruchom mimo wszystko”."},
+"pt":{"header.affiliation":"O TurboWarp não tem afiliação com o Scratch, a Equipe do Scratch ou a Fundação Scratch.","header.subtitle":"Use o {TurboWarp}, o mod do Scratch com um compilador, modo escuro, addons, e mais, em um app no seu computador. Até funciona sem internet.","linux.snapTitle":"Baixe pela Snap Store","picture.caption":"Projeto na imagem: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Projeto na imagem: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidade","source":"Código-fonte","update.linux":"Se você instalou o TurboWarp Desktop de uma loja de aplicativo ou administrador de pacote como a Snap Store, espere até a atualização ser publicada na loja. Senão, rode o novo instalador abaixo.","update.mac":"Para atualizar, baixe e execute o novo aplicativo abaixo.","update.windows":"Para atualizar, baixe e execute o novo instalador abaixo."},
+"ro":{"header.affiliation":"TurboWarp nu este conectat cu Scratch, Echipa Scratch, sau Fundația Scratch."},
+"ru":{"header.affiliation":"TurboWarp не связан с Scratch, Командой Scratch или Фондом Scratch .","header.subtitle":"Используйте {TurboWarp}, модификацию Scratch с компилятором, темным режимом, дополнения и многое другое из приложения на рабочем столе. Оно работает даже в офлайн-режиме.","linux.snapTitle":"Получите в Snap Store","picture.caption":"Изображённый проект: {project}","picture.caption.project":"Full Sphere Path Tracer от piano_miles","picture.title":"Изображённый проект: Full Sphere Path Tracer от piano_miles","privacy":"Политика конфиденциальности","source":"Исходный код","update.linux":"Если вы установили TurboWarp Desktop из магазина приложений или диспетчера пакетов, такого как Snap Store, дождитесь, пока обновление будет отправлено в магазин. В противном случае запустите новый установочный файл ниже.","update.mac":"Чтобы обновить, скачайте и установите приложение ниже.","update.windows":"Чтобы обновить, скачайте и запустите установочный файл ниже."},
+"sl":{"header.affiliation":"TurboWarp ni povezan s Scratchem, skupino Scratch ali fundacijo Scratch.","header.subtitle":"Uporabljajte {TurboWarp}, spremenjeno različico Scratcha s prevajalnikom kode, temnim načinom, dodatki in drugimi funkcijami, kot aplikacijo na svojem računalniku. Deluje tudi brez internetne povezave.","linux.snapTitle":"Namestitev iz trgovine Snap Store","picture.caption":"Projekt na sliki: {project}","picture.caption.project":"Full Sphere Path Tracer avtorja piano_miles","picture.title":"Projekt na sliki: Full Sphere Path Tracer avtorja piano_miles","privacy":"Politika zasebnosti","source":"Izvirna koda","update.linux":"Če ste namestili TurboWarp Desktop s pomočjo trgovine z aplikacijami ali upravitelja paketov, kot je Snap Store, počakajte, dokler posodobitev ni na voljo v trgovini. Sicer zaženite nov namestitveni program spodaj.","update.mac":"Za posodobitev spodaj prenesite in namestite novo aplikacijo.","update.windows":"Za posodobitev spodaj prenesite nov namestitveni program."},
+"sv":{"source":"Källkod"},
+"tr":{"githubBugs":"Hataları GitHub'da bildir","header.affiliation":"TurboWarp, Scratch, Scratch Takım veya Scratch Vakıfı ile bağlantılı değildir.","header.subtitle":"{TurboWarp}'u kullan, bir derleyici olan Scratch modu, karanlık modu, eklentiler ve çevrimdışı olduğunuzda bile çalışır.","linux.anywhere":"Tüm dağıtımlarda çalışır.","linux.choices":"Linux kullanıcılarının bazı seçenekleri vardır.","linux.snapTitle":"Snap Storundan alın","linux.terminal":"Bunu bir terminalde çalıştır","linux.uninstall":"Kaldır","mac.download":"macOS için İndir (Evrensel)","mac.help":"Eğer bir Gatekeeper iletisi gözükürse, Finder'ı açın, Uygulamalar kısmına gidin, TurboWarp'a sağ tıklayın ve \"Aç\" tuşunu seçin, ardından tekrar \"Aç\" tuşuna basın.","picture.caption":"Fotoğrafta gösterilen proje: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"Fotoğrafta gösterilen proje: piano_miles tarafından Full Sphere Path Tracer","privacy":"Gizillik politikası","pwa.help":"Daha sonra URL'deki indir butonuna bas. Görünmesi birkaç saniye alabilir.","pwa.open":"TurboWarp Websitesi'ni Aç","scratchBugs":"Hataları Scratch'te bildir","source":"Kaynak kodu","update.linux":"Eğer Turbowarp Desktop'u bir uygulama mağazasından örneğin Snap Store indirirsen, güncelleme mağazaya aktarılana kadar bekleyin. Aksi takdirde, aşağıdaki yeni yükleyiciyi çalıştırın.","update.mac":"Güncellemek için, yeni yükleyiciği aşağıda indirin.","update.windows":"Güncellemek için, yeni yükleyiciği aşağıda çalıştır.","win.32":"32-bit sistemler için alternatif indirme","win.download":"Windows için İndir (64-bit)","win.help":"Eğer bir Windows SmartScreen uyarısı gözükürse, \"Daha fazla bilgi\" ve ardından \"Yine de çalıştır\" tuşlarına basınız."},
+"zh-cn":{"header.affiliation":"TurboWarp 不属于 Scratch、Scratch 团队或 Scratch 基金会。","header.subtitle":"在你的电脑上使用 {TurboWarp}，一个拥有编译器、深色模式、插件等功能的 Scratch 修改版。它甚至还能在你离线的时候运行。","linux.snapTitle":"从 Snap Store 获取","picture.caption":"图片中的作品：{project}","picture.caption.project":"由 piano_miles 制作的 Full Sphere Path Tracer","picture.title":"图片中的作品：由 piano_miles 制作的 Full Sphere Path Tracer","privacy":"隐私政策","source":"源代码","update.linux":"如果你从像 Snap Store 一样的应用商店或包管理器安装了 TurboWarp Desktop，请等待更新推送到该商店。否则，请运行下面的新安装程序。","update.mac":"在下面下载并安装新的应用程序以更新。","update.windows":"在下面下载并运行新的安装程序以更新。"},
+"zh-tw":{"header.affiliation":"TurboWarp 並不隸屬於 Scratch、Scratch 團隊或 Scratch 基金會。","header.subtitle":"{TurboWarp}，運行更快且帶有黑暗模式、附加元件及其他好用功能的 Scratch，可在電腦和手機上使用，離線亦然。","linux.snapTitle":"從 Snap Store 安裝","picture.caption":"上圖專案：{project}","picture.caption.project":"Full Sphere Path Tracer，作者：piano_miles","picture.title":"上圖專案：Full Sphere Path Tracer，作者：piano_miles","privacy":"隱私政策","source":"原始碼","update.linux":"若你是從應用商店或軟體套件管理系統（如 Snap Store）安裝 TurboWarp 的，就必須等到它放上更新。或者，運行下方的安裝程式。","update.mac":"下載並安裝新版程式以更新。","update.windows":"下載並運行下方的新版安裝程式以更新。"},
+}/*===*/;
+
+        const translatableElements = document.querySelectorAll('[data-l10n]');
+        const translatableAttributes = document.querySelectorAll('[data-l10n-attrib]');
+
+        function getId(el) {
+          if (el.getAttribute('data-l10n-subkey')) return el.getAttribute('data-l10n-subkey');
+          return el.textContent.trim().replace(/\s+/g, '_').replace(/[^a-z_0-9]/gi, '') || ('placeholder' + j);
         }
 
-        @media (prefers-color-scheme: dark) {
-          body {
-            background: #171717;
-            color: #eee;
-          }
-          a {
-            color: #4af;
-          }
-          code, .code {
-            background-color: #222;
-          }
-          a code {
-            color: #4af;
-          }
-          hr {
-            border-color: #333;
-          }
-          .select-os {
-            box-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
-            background: #1a1a1a;
-          }
-          .select-os-inner button {
-            color: white;
-            background-color: rgba(255, 255, 255, 0.2);
-          }
-          .link:hover {
-            background-color: #333;
-          }
-          .picture-dark {
-            display: block;
-          }
-          .picture-light {
-            display: none;
-          }
-          :focus-visible {
-            outline: 2px solid white;
-          }
-        }
-      </style>
-    </head>
+        function translate(language) {
+          if (!allLanguageMessages[language]) language = language.split('-')[0];
+          const messages = allLanguageMessages[language];
+          if (!messages) return;
+          document.documentElement.lang = language;
 
-    <!--
-      Some icons are from Font Awesome https://fontawesome.com/
-      For license information, visit https://creativecommons.org/licenses/by/4.0/
-      Icons have been minified by hand.
-    -->
+          for (const el of translatableElements) {
+            const nodes = el.childNodes;
+            const namedNodes = {};
+            const key = el.getAttribute('data-l10n');
+            const message = messages[key];
 
-    <body os="">
-      <section class="header visible-loading">
-        <div>
-          <h1 class="header-title">
-            <svg aria-hidden="true" viewBox="0 0 1024 1024">
-              <path d="m64 174.86735v641.13265c0 35.34622 28.653776 64 64 64h113.30332c9.32935 0 18.19416 4.07135 24.27337 11.14807l67.26992 78.30776c12.15843 14.15343 29.88806 22.29614 48.54676 22.29614h261.21326c18.6587 0 36.38832-8.14271 48.54676-22.29614l67.26992-78.30776c6.07921-7.07672 14.94402-11.14807 24.27337-11.14807h113.30332c35.34622 0 64-28.65378 64-64v-654.84694c0-35.34622-28.65378-64-64-64-0.38091 0-0.76182 0.0034-1.14268 0.0102l-767.99999 13.71429c-34.89522 0.62313-62.85733 29.08902-62.85733 63.9898z" fill="#cc3c3c" fill-rule="evenodd"/>
-              <path d="m64 96v672c0 35.34622 28.653776 64 64 64h128.17394c9.97413 0 19.37789 4.65076 25.43168 12.5776l51.18313 67.01917c12.1076 15.85368 30.9151 25.1552 50.86336 25.1552h256.69578c19.94826 0 38.75576-9.30152 50.86336-25.1552l51.18312-67.01917c6.0538-7.92684 15.45756-12.5776 25.43169-12.5776h128.17394c35.34622 0 64-28.65378 64-64v-672c0-35.346224-28.65378-64-64-64h-768c-35.346224 0-64 28.653776-64 64z" fill="#ff4c4c" fill-rule="evenodd"/>
-              <path d="m96 96v672c0 17.67311 14.32689 32 32 32h128.17394c19.94827 0 38.75577 9.30152 50.86337 25.1552l51.18312 67.01917c6.0538 7.92684 15.45755 12.5776 25.43168 12.5776h256.69578c9.97413 0 19.37788-4.65076 25.43168-12.5776l51.18312-67.01917c12.1076-15.85368 30.9151-25.1552 50.86337-25.1552h128.17394c17.67311 0 32-14.32689 32-32v-672c0-17.673112-14.32689-32-32-32h-768c-17.67311 0-32 14.326888-32 32zm-32 0c0-35.346224 28.653776-64 64-64h768c35.34622 0 64 28.653776 64 64v672c0 35.34622-28.65378 64-64 64h-128.17394c-9.97413 0-19.37789 4.65076-25.43169 12.5776l-51.18312 67.01917c-12.1076 15.85368-30.9151 25.1552-50.86336 25.1552h-256.69578c-19.94826 0-38.75576-9.30152-50.86336-25.1552l-51.18313-67.01917c-6.05379-7.92684-15.45755-12.5776-25.43168-12.5776h-128.17394c-35.346224 0-64-28.65378-64-64z" fill="#fff" fill-opacity=".2"/>
-              <g transform="matrix(4.1943736,0,0,4.1943736,229.13567,171.21359)" fill="none" stroke="#fff" stroke-width="56.4093">
-               <path d="m108.34581 31.577677c-0.79395 3.473563-1.38942 7.244861-1.7864 11.313892-0.0992 1.091691 0 2.481117 0.29773 4.168276 0.29773 1.984893 0.4466 3.374319 0.4466 4.168276 0 2.580361-1.68716 3.870542-5.06147 3.870542-2.18339 0-3.622435-0.64509-4.317148-1.935271-0.09925-2.183383-0.04962-5.160723 0.14887-8.93202 0.198487-4.46601 0.29773-7.44335 0.29773-8.93202-0.09924 0-0.248107-0.09924-0.4466-0.297734-9.229753 0.396979-17.91366 0.992447-26.05172 1.786404-0.198493 1.290181-0.198493 2.878095 0 4.763744l0.59546 5.359212c-0.396973 3.076585-0.59546 7.64184-0.59546 13.695765 0.297733 2.580361 0.4466 13.646143 0.4466 33.197344v10.867303c0 1.68716 0.24811 2.8781 0.74433 3.57281h9.22976c3.771293-0.49623 5.65694 1.09169 5.65694 4.76374 0 2.18339-1.042067 3.72168-3.1262 4.61488-1.290187 0.49623-3.572817 0.59547-6.84789 0.29774-1.984893-0.19849-4.317143-0.24812-6.99675-0.14887-3.672053 0.49622-8.138063 0.8932-13.39803 1.19093-5.359207 0.29774-8.634279-0.44659-9.825218-2.233-0.793957-1.19093-0.793957-2.43149 0-3.72168 1.389425-2.18338 5.011855-3.27507 10.867288-3.27507 3.076587 0 4.61488-0.84358 4.61488-2.53074 0-0.8932-0.04962-1.73678-0.14887-2.53074 0-2.48113 0.04962-4.66452 0.14887-6.550163 0.297733-5.359213 0.297733-12.901808 0-22.627784-0.39698-14.092743-0.248113-26.746439 0.4466-37.961086l-0.4466-0.446601c-3.076587 0.198489-8.832777 0.148867-17.268572-0.148867-0.396979 0-3.423941 0.198489-9.080887 0.595468 1.389425 9.527488 2.183383 16.325748 2.381872 20.394779l-0.297734 4.01941c-0.09924 1.48867-1.339803 2.233005-3.721676 2.233005-1.885649 0-3.473563-3.572808-4.763744-10.718425-0.595468-4.267521-1.190936-8.584664-1.786404-12.951429 0-0.694713-0.347356-1.885649-1.042069-3.572808-0.595468-1.786404-1.908676-4.750966-1.908676-5.644168 0-3.141175 2.901123-2.39465 6.67242-2.990118 0.297734 0 0.793957 0.04962 1.48867 0.148867 0.694713 0.09924 1.190936 0.148867 1.48867 0.148867h36.91902c9.130507-0.396979 17.96328-1.190936 26.49832-2.381872 0.595473-0.297734 1.488678-0.595468 2.679608-0.893202 2.08414-0.19849 3.87054 0.297733 5.35921 1.48867 1.48867 1.091691 1.9849 2.679606 1.48867 4.763744z" fill="none" stroke="#fff" stroke-width="56.4093"/>
-              </g>
-              <g transform="matrix(3.852509,0,0,3.852509,257.89982,219.83848)" fill="none" stroke="#ff4c4c" stroke-width="30.7075">
-               <path d="m110.38498 21.776581q-1.29661 5.672702-1.94492 12.317866-0.16208 1.782849 0.32415 4.538161 0.48623 3.241544 0.48623 4.538161 0 4.214007-5.51062 4.214007-3.5657 0-4.700239-2.107004-0.16208-3.565698 0.16208-9.72463 0.32415-7.293474 0.32415-9.724631-0.16207 0-0.48623-0.324155-15.073176 0.648309-28.3635 1.944927-0.324161 2.107003 0 5.186469l0.6483 5.834779q-0.6483 5.024392-0.6483 14.911102 0.48623 4.214006 0.48623 36.143214v11.831633q0 2.75531 0.81038 3.88985h10.048792q6.158927-0.81039 6.158927 5.18647 0 3.5657-3.403614 5.0244-2.107013 0.81039-7.455559 0.32416-3.241543-0.32416-7.617628-0.16208-5.996857 0.81038-14.586946 1.29661-8.75216 0.48624-10.69709-2.43115-1.296617-1.94493 0-4.05194 2.26908-3.56569 11.831631-3.56569 5.024396 0 5.024396-2.75532 0-1.45869-0.162081-2.75531 0-4.051935 0.162081-7.131398 0.48623-8.75217 0-24.635731-0.648311-23.014961 0.48623-41.329683l-0.48623-0.486231q-5.024396 0.324154-18.800953-0.162077-0.648309 0-9.886708 0.648308 2.26908 15.55941 2.593235 22.204574 0 0-0.324155 4.376085-0.162077 2.431158-4.05193 2.431158-3.079467 0-5.18647-11.669558-0.972463-6.969319-1.944926-14.100715 0-1.13454-1.134541-3.889852-0.972463-2.91739-0.972463-4.376084 0-4.05193 6.158933-5.024393 0.486232 0 1.620772 0.162077 1.13454 0.162078 1.620772 0.162078h16.856029q23.339116 0 23.339116 0 14.911096-0.648309 28.849729-2.593235 0.97247-0.486232 2.91739-0.972463 3.40363-0.324156 5.83478 1.620771 2.43116 1.782849 1.62077 5.18647z" fill="none" stroke="#ff4c4c" stroke-width="30.7075"/>
-              </g>
-              <g transform="matrix(4.1943736,0,0,4.1943736,228.25358,197.35677)" fill="#fff">
-               <path d="m108.34581 25.3789q-1.19093 5.210345-1.7864 11.313892-0.14887 1.637537 0.29773 4.168276 0.4466 2.97734 0.4466 4.168276 0 3.870542-5.06147 3.870542-3.275078 0-4.317148-1.935271-0.14887-3.275074 0.14887-8.93202 0.29773-6.699015 0.29773-8.93202-0.14886 0-0.4466-0.297734-13.84463 0.595468-26.05172 1.786404-0.29774 1.935271 0 4.763744l0.59546 5.359212q-0.59546 4.614877-0.59546 13.695765 0.4466 3.870542 0.4466 33.197344v10.86729q0 2.53074 0.74433 3.57281h9.22976q5.65694-0.74434 5.65694 4.76374 0 3.27508-3.1262 4.61488-1.93528 0.74434-6.84789 0.29774-2.97734-0.29774-6.99675-0.14887-5.50808 0.74433-13.39803 1.19093-8.03881 0.44661-9.825218-2.233-1.190936-1.7864 0-3.72168 2.084138-3.27507 10.867288-3.27507 4.61488 0 4.61488-2.53074 0-1.3398-0.14887-2.53074 0-3.72168 0.14887-6.55015 0.4466-8.03882 0-22.627784-0.59547-21.139115 0.4466-37.961086l-0.4466-0.446601q-4.61488 0.297734-17.268572-0.148867-0.595468 0-9.080887 0.595468 2.084138 14.291232 2.381872 20.394779 0 0-0.297734 4.01941-0.148867 2.233005-3.721676 2.233005-2.828473 0-4.763744-10.718425-0.893202-6.401281-1.786404-12.951429 0-1.042069-1.042069-3.572808-0.893202-2.679606-0.893202-4.019409 0-3.721675 5.656946-4.614877 0.446601 0 1.48867 0.148867t1.48867 0.148867h15.48217q21.43685 0 21.43685 0 13.69576-0.595468 26.49832-2.381872 0.89321-0.446601 2.679608-0.893202 3.12621-0.297735 5.35921 1.48867 2.23301 1.637537 1.48867 4.763744z" fill="#fff"/>
-              </g>
-            </svg>
-            <div>TurboWarp Desktop</div>
-          </h1>
-          <div class="header-subtitles">
-            <noscript><p>This page requires JavaScript.</p></noscript>
-            <p data-l10n="header.subtitle" class="transparent-loading">Use <a href="https://turbowarp.org" data-notranslate>TurboWarp</a>, the Scratch mod with a compiler, dark mode, addons, and more, from an app on your desktop. It even works when you're offline!</p>
-            <p class="transparent-loading"><i data-l10n="header.affiliation">TurboWarp is not affiliated with Scratch, the Scratch Team, or the Scratch Foundation.</i></p>
-          </div>
-        </div>
-      </section>
+            if (!message) {
+              console.warn('Missing message: ' + key);
+              continue;
+            }
 
-      <section class="select-os" id="select-os">
-        <div class="select-os-inner">
-          <div class="select-os-buttons">
-            <button class="os-button-windows">
-              <!-- Icon from https://fontawesome.com/icons/windows?style=brands -->
-              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"></path></svg>
-              <div>
-                Windows
-              </div>
-            </button>
-            <button class="os-button-mac">
-              <!-- Icon from https://fontawesome.com/icons/apple?style=brands -->
-              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"></path></svg>
-              <div>
-                macOS
-              </div>
-            </button>
-            <button class="os-button-linux">
-              <!-- Icon from https://fontawesome.com/icons/linux?style=brands -->
-              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-6.5 5.8-11.4 14.7-16.6 20.2-4.2 4.3-10.3 5.9-17 8.3s-14 6-18.5 14.5c-2.1 3.9-2.8 8.1-2.8 12.4 0 3.9.6 7.9 1.2 11.8 1.2 8.1 2.5 15.7.8 20.8-5.2 14.4-5.9 24.4-2.2 31.7 3.8 7.3 11.4 10.5 20.1 12.3 17.3 3.6 40.8 2.7 59.3 12.5 19.8 10.4 39.9 14.1 55.9 10.4 11.6-2.6 21.1-9.6 25.9-20.2 12.5-.1 26.3-5.4 48.3-6.6 14.9-1.2 33.6 5.3 55.1 4.1.6 2.3 1.4 4.6 2.5 6.7v.1c8.3 16.7 23.8 24.3 40.3 23 16.6-1.3 34.1-11 48.3-27.9 13.6-16.4 36-23.2 50.9-32.2 7.4-4.5 13.4-10.1 13.9-18.3.4-8.2-4.4-17.3-15.5-29.7zM223.7 87.3c9.8-22.2 34.2-21.8 44-.4 6.5 14.2 3.6 30.9-4.3 40.4-1.6-.8-5.9-2.6-12.6-4.9 1.1-1.2 3.1-2.7 3.9-4.6 4.8-11.8-.2-27-9.1-27.3-7.3-.5-13.9 10.8-11.8 23-4.1-2-9.4-3.5-13-4.4-1-6.9-.3-14.6 2.9-21.8zM183 75.8c10.1 0 20.8 14.2 19.1 33.5-3.5 1-7.1 2.5-10.2 4.6 1.2-8.9-3.3-20.1-9.6-19.6-8.4.7-9.8 21.2-1.8 28.1 1 .8 1.9-.2-5.9 5.5-15.6-14.6-10.5-52.1 8.4-52.1zm-13.6 60.7c6.2-4.6 13.6-10 14.1-10.5 4.7-4.4 13.5-14.2 27.9-14.2 7.1 0 15.6 2.3 25.9 8.9 6.3 4.1 11.3 4.4 22.6 9.3 8.4 3.5 13.7 9.7 10.5 18.2-2.6 7.1-11 14.4-22.7 18.1-11.1 3.6-19.8 16-38.2 14.9-3.9-.2-7-1-9.6-2.1-8-3.5-12.2-10.4-20-15-8.6-4.8-13.2-10.4-14.7-15.3-1.4-4.9 0-9 4.2-12.3zm3.3 334c-2.7 35.1-43.9 34.4-75.3 18-29.9-15.8-68.6-6.5-76.5-21.9-2.4-4.7-2.4-12.7 2.6-26.4v-.2c2.4-7.6.6-16-.6-23.9-1.2-7.8-1.8-15 .9-20 3.5-6.7 8.5-9.1 14.8-11.3 10.3-3.7 11.8-3.4 19.6-9.9 5.5-5.7 9.5-12.9 14.3-18 5.1-5.5 10-8.1 17.7-6.9 8.1 1.2 15.1 6.8 21.9 16l19.6 35.6c9.5 19.9 43.1 48.4 41 68.9zm-1.4-25.9c-4.1-6.6-9.6-13.6-14.4-19.6 7.1 0 14.2-2.2 16.7-8.9 2.3-6.2 0-14.9-7.4-24.9-13.5-18.2-38.3-32.5-38.3-32.5-13.5-8.4-21.1-18.7-24.6-29.9s-3-23.3-.3-35.2c5.2-22.9 18.6-45.2 27.2-59.2 2.3-1.7.8 3.2-8.7 20.8-8.5 16.1-24.4 53.3-2.6 82.4.6-20.7 5.5-41.8 13.8-61.5 12-27.4 37.3-74.9 39.3-112.7 1.1.8 4.6 3.2 6.2 4.1 4.6 2.7 8.1 6.7 12.6 10.3 12.4 10 28.5 9.2 42.4 1.2 6.2-3.5 11.2-7.5 15.9-9 9.9-3.1 17.8-8.6 22.3-15 7.7 30.4 25.7 74.3 37.2 95.7 6.1 11.4 18.3 35.5 23.6 64.6 3.3-.1 7 .4 10.9 1.4 13.8-35.7-11.7-74.2-23.3-84.9-4.7-4.6-4.9-6.6-2.6-6.5 12.6 11.2 29.2 33.7 35.2 59 2.8 11.6 3.3 23.7.4 35.7 16.4 6.8 35.9 17.9 30.7 34.8-2.2-.1-3.2 0-4.2 0 3.2-10.1-3.9-17.6-22.8-26.1-19.6-8.6-36-8.6-38.3 12.5-12.1 4.2-18.3 14.7-21.4 27.3-2.8 11.2-3.6 24.7-4.4 39.9-.5 7.7-3.6 18-6.8 29-32.1 22.9-76.7 32.9-114.3 7.2zm257.4-11.5c-.9 16.8-41.2 19.9-63.2 46.5-13.2 15.7-29.4 24.4-43.6 25.5s-26.5-4.8-33.7-19.3c-4.7-11.1-2.4-23.1 1.1-36.3 3.7-14.2 9.2-28.8 9.9-40.6.8-15.2 1.7-28.5 4.2-38.7 2.6-10.3 6.6-17.2 13.7-21.1.3-.2.7-.3 1-.5.8 13.2 7.3 26.6 18.8 29.5 12.6 3.3 30.7-7.5 38.4-16.3 9-.3 15.7-.9 22.6 5.1 9.9 8.5 7.1 30.3 17.1 41.6 10.6 11.6 14 19.5 13.7 24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4s5.9-6.3 3.1-6.6-2.6 2.6-6 5.1c-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2s-18.7-4.8-24.9-9.7c-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z"></path></svg>
-              <div>
-                Linux
-              </div>
-            </button>
-            <button class="os-button-chrome">
-              <!-- Icon from https://fontawesome.com/v5.15/icons/chrome?style=brands -->
-              <svg class="os-button-icon" aria-hidden="true" focusable="false" role="img" viewBox="0 0 496 512"><path fill="currentColor" d="M131.5 217.5L55.1 100.1c47.6-59.2 119-91.8 192-92.1 42.3-.3 85.5 10.5 124.8 33.2 43.4 25.2 76.4 61.4 97.4 103L264 133.4c-58.1-3.4-113.4 29.3-132.5 84.1zm32.9 38.5c0 46.2 37.4 83.6 83.6 83.6s83.6-37.4 83.6-83.6-37.4-83.6-83.6-83.6-83.6 37.3-83.6 83.6zm314.9-89.2L339.6 174c37.9 44.3 38.5 108.2 6.6 157.2L234.1 503.6c46.5 2.5 94.4-7.7 137.8-32.9 107.4-62 150.9-192 107.4-303.9zM133.7 303.6L40.4 120.1C14.9 159.1 0 205.9 0 256c0 124 90.8 226.7 209.5 244.9l63.7-124.8c-57.6 10.8-113.2-20.8-139.5-72.5z"></path></svg>
-              <div>
-                Chrome
-              </div>
-            </button>
-          </div>
-        </div>
-      </section>
+            for (const node of nodes) {
+              if (node.nodeName === '#text') continue;
+              const id = getId(node);
+              namedNodes[id] = node;
+              const message = messages[key + '.' + id];
+              if (message) {
+                node.textContent = message;
+              }
+            }
 
-      <section class="changelog">
-        <div>
-          <h2>Changes from v0.8.1 to v0.9.0</h2>
-          <ul>
-            <li>New addon: Paint costume by default</li>
-            <li>New addon: Hide delete button</li>
-            <li>New addon: Do not automatically space overlapping scripts</li>
-            <li class="os-windows">Windows: We now support 32-bit systems</li>
-            <li>You can now create cloud variables. However, they won't actually work unless uploaded to Scratch or a tool such as the TurboWarp Packager</li>
-            <li>Various bug fixes</li>
-            <li>Updated translations</li>
-          </ul>
-          <p class="os-windows" data-l10n="update.windows">To update, download and run the new installer below.</p>
-          <p class="os-mac" data-l10n="update.mac">To update, download and install the new app below.</p>
-          <p class="os-linux" data-l10n="update.linux">If you installed TurboWarp Desktop from an app store or package manager such as the Snap Store, wait until the update is pushed to the store. Otherwise, run the new installer below.</p>
-        </div>
-      </section>
+            while (el.firstChild) el.removeChild(el.firstChild);
 
-      <section class="os os-windows">
-        <div>
-          <div class="download-button-outer">
-            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-x64.exe">
-              <div class="download-icon"></div>
-              <div data-l10n="win.download">Download for Windows (64-bit)</div>
-            </a>
-          </div>
-          
-          &nbsp;
-
-          <div class="download-button-outer">
-            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}-ia32.exe">
-              <div class="download-icon"></div>
-              <div data-l10n="win.download">Download for Windows (32-bit)</div>
-            </a>
-          </div>
-          
-          <div class="install-help">
-            <p data-l10n="win.help">If a Windows SmartScreen alert appears, click "More info" then "Run anyways".</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="os os-mac">
-        <div>
-          <div class="download-button-outer">
-            <a class="download-button-inner" data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-Setup-{version}.dmg">
-              <div class="download-icon"></div>
-              <div data-l10n="mac.download">Download for macOS (Universal)</div>
-            </a>
-          </div>
-
-          <div class="install-help">
-            <div data-l10n="mac.help">If a Gatekeeper prompt appears, open Finder, navigate to Applications, right click TurboWarp and select "Open" and then "Open" again.</div>
-          </div>
-        </div>
-      </section>
-
-      <section class="os os-linux">
-        <div>
-          <p data-l10n="linux.choices">Linux users have some choices.</p>
-          <hr>
-
-          <h2 data-l10n="linux.terminal">Run this in a terminal</h2>
-          <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/install.sh)"</code></p>
-          <p data-l10n="linux.anywhere">Works on any distribution.</p>
-          <hr>
-
-          <h2>Snap Store</h2>
-          <p>
-            <a href="https://snapcraft.io/turbowarp-desktop">
-              <!-- Image from https://github.com/snapcore/snap-store-badges -->
-              <img data-src="snap-store.png" width="182" height="56" alt="Get it from the Snap Store" title="Get it from the Snap Store" data-l10n-attrib="alt=linux.snapTitle,title=linux.snapTitle" style="display: inline;">
-            </a>
-          </p>
-          <hr>
-
-          <h2>Debian, Ubuntu, Raspberry Pi OS, etc.:</h2>
-          <ul>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-amd64-{version}.deb">x86 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.deb">x86 32-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.deb">ARM 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.deb">ARMv7l</a></li>
-          </ul>
-          <hr>
-
-          <h2>AppImage</h2>
-          <ul>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x86_64-{version}.AppImage">x86 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.AppImage">x86 32-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.AppImage">ARM 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.AppImage">ARMv7l</a></li>
-          </ul>
-          <hr>
-
-          <h2>Tarball</h2>
-          <ul>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x64-{version}.tar.gz">x86 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-ia32-{version}.tar.gz">x86 32-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.tar.gz">ARM 64-bit</a></li>
-            <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.tar.gz">ARMv7l</a></li>
-          </ul>
-          <hr>
-
-          <h2 data-l10n="linux.uninstall">Uninstall</h2>
-          <p><code class="command">sudo bash -c "$(wget -qO- https://desktop.turbowarp.org/uninstall.sh)"</code></p>
-        </div>
-      </section>
-
-      <section class="os os-chrome">
-        <div>
-          <div class="download-button-outer">
-            <a class="download-button-inner" href="https://turbowarp.org/" target="_blank" rel="noopener">
-              <div data-l10n="pwa.open">Open the TurboWarp Website</div>
-            </a>
-          </div>
-
-          <div class="install-help">
-            <p data-l10n="pwa.help">Then press the install button in the URL. It may take a few seconds to appear.</p>
-            <img data-src="pwa-install.png" width="620" height="258"class="pwa-install">
-          </div>
-        </div>
-      </section>
-
-      <section class="links">
-        <div class="links-inner">
-          <a class="link" href="https://github.com/TurboWarp/desktop/">
-            <div class="icon">
-              <!-- Icon from https://fontawesome.com/v5.15/icons/code?style=solid -->
-              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg>
-            </div>
-            <div data-l10n="source">Source code</div>
-          </a>
-          <a class="link" href="privacy.html">
-            <div class="icon">
-              <!-- Icon from https://fontawesome.com/v5.15/icons/file?style=solid -->
-              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg>
-            </div>
-            <div data-l10n="privacy">Privacy policy</div>
-          </a>
-          <a class="link" href="https://scratch.mit.edu/users/GarboMuffin/#comments">
-            <div class="icon">
-              <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
-              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
-            </div>
-            <div data-l10n="scratchBugs">Report bugs on Scratch</div>
-          </a>
-          <a class="link" href="https://github.com/TurboWarp/desktop/issues">
-            <div class="icon">
-              <!-- Icon from https://fontawesome.com/v5.15/icons/bug?style=solid -->
-              <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
-            </div>
-            <div data-l10n="githubBugs">Report bugs on GitHub</div>
-          </a>
-        </div>
-      </section>
-
-      <section class="picture-container">
-        <img class="picture picture-light" data-src="screenshot-light.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
-        <img class="picture picture-dark" data-src="screenshot-dark.png" width="1280" height="800" title="Project pictured: Full Sphere Path Tracer by piano_miles" data-l10n-attrib="title=picture.title">
-        <p class="picture-caption" data-l10n="picture.caption">Project pictured: <a href="https://scratch.mit.edu/projects/425020125/" data-l10n-subkey="project">Full Sphere Path Tracer by piano_miles</a></p>
-      </section>
-
-      <script>
-        window.L = (function () {
-          const allLanguageMessages = /*===*/{
-  "de":{"header.affiliation":"TurboWarp ist nicht mit Scratch, dem Scratch Team oder der Scratch-Stiftung verbunden.","header.subtitle":"Verwende {TurboWarp}, das Scratch-Mod mit einem Compiler, Dunkelmodus, Addons und mehr, mit einer App auf deinem Desktop. Es funktioniert auch, wenn du offline bist.","linux.snapTitle":"Vom Snap-Store holen","picture.caption":"Abgebildetes Projekt: {project}","picture.caption.project":"Full Sphere Path Tracer von piano_miles","picture.title":"Angezeigtes Projekt: Full Sphere Path Tracer von piano_miles","privacy":"Datenschutzerklärung","source":"Quellcode","update.linux":"Falls du TurboWarp Desktop von einem App-Store oder Paketmanager wie dem Snap-Store installiert hast, warte bis das Update im Store verfügbar ist. Ansonsten kannst du unten den neuen Installer ausführen","update.mac":"Lade die neue App herunter und führe sie aus, um TurboWarp zu aktualisieren.","update.windows":"Lade den Installer herunter und führe ihn aus, um TurboWarp zu aktualisieren."},
-  "es":{"header.affiliation":"TurboWarp no está afiliado con Scratch, el equipo de Scratch o la Scratch Foundation.","header.subtitle":"Use {TurboWarp}, el mod de Scratch con compilador, modo oscuro, addons y más, desde una app en su escritorio. Funciona incluso sin una conexión a internet.","linux.snapTitle":"Obtener en la Snap Store","picture.caption":"Proyecto en imagen: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Proyecto en la imagen: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidad","source":"Código fuente","update.linux":"Si instaló TurboWarp Desktop desde una tienda de aplicaciones o administrador de paquetes, por ejemplo la Snap Store, espere hasta que la actualización se publique en la tienda. De lo contrario, ejecute el nuevo instalador debajo.","update.mac":"Para actualizar, descargue e instale la app debajo.","update.windows":"Para actualizar, descargue y ejecute el instalador debajo."},
-  "fr":{"githubBugs":"Rapporter des bugs sur GitHub","header.affiliation":"TurboWarp n'est pas affilié à Scratch, à l'équipe Scratch ou à la Fondation Scratch.","header.subtitle":"Utilisez {TurboWarp}, le mod Scratch avec un compilateur, un mode sombre, des modules complémentaires et plus encore, à partir d'une application sur votre bureau. Cela fonctionne même lorsque vous êtes hors ligne.","linux.choices":"Les utilisateurs de Linux ont du choix.","linux.terminal":"Lancer dans une console","linux.uninstall":"Désinstaller","mac.download":"Télécharger pour macOS (universel)","privacy":"Politique de Confidentialité","pwa.help":"Appuyez sur le bouton d'installation à l'aide de l'URL. Cela peut prendre quelques secondes à apparaître.","pwa.open":"Ouvrir le site de TurboWarp","scratchBugs":"Rapporter des bugs sur Scratch","source":"Code source","update.linux":"Si vous avez installé TurboWarp Desktop à partir d'un magasin d'applications ou d'un gestionnaire de packages tel que Snap Store, attendez que la mise à jour soit envoyée au magasin. Sinon, exécutez le nouveau programme d'installation ci-dessous.","update.mac":"Pour mettre à jour, téléchargez et installez la nouvelle application ci-dessous.","update.windows":"Pour mettre à jour, téléchargez et exécutez le nouveau programme d'installation ci-dessous.","win.32":"Télécharger pour des systèmes 32-bit","win.download":"Télécharger pour Windows (64-bit)"},
-  "it":{"githubBugs":"Notifica i bug su GitHub","header.affiliation":"TurboWarp non è affiliato a Scratch, allo Scratch Team o alla Scratch Foundation.","header.subtitle":"Usa {TurboWarp}, la mod di Scratch dotata di compilatore, dark mode, addon e molto altro come app sul tuo PC. Funziona anche quando non sei online.","linux.anywhere":"Funziona per qualunque distribuzione.","linux.choices":"Gli utenti Linux hanno alcune possibili scelte.","linux.snapTitle":"Ottienilo dallo Snap Store","linux.terminal":"Esegui questo comando in una finestra di Terminale","linux.uninstall":"Disinstalla","mac.download":"Scarica per macOS (Universale)","mac.help":"Se appare un avviso di Gatekeeper apri il Finder, vai ad Applicazioni, clicca TurboWarp con il tasto destro e poi seleziona \"Apri\" e di nuovo \"Apri\".","picture.caption":"Progetto mostrato: {project}","picture.caption.project":"Full Sphere Path Tracer di piano_miles","picture.title":"Progetto: Full Sphere Path Tracer di piano_miles","privacy":"Politica delle privacy","pwa.help":"Premi il pulsante di installazione nella barra dell'indirizzo. Potrebbero essere necessari alcuni secondi prima che appaia.","pwa.open":"Apri il sito TurboWarp","scratchBugs":"Notifica i bug su Scratch","source":"Codice sorgente","update.linux":"Se hai installato TurboWarp Desktop da un app store o usando un gestore di pacchetti come Snap Store attendi fino a che l'aggiornamento è presente nello store. In alternativa puoi eseguire il nuovo installatore che trovi qui sotto.","update.mac":"Per aggiornare, scaricare ed eseguire la nuova app qui sotto.","update.windows":"Per aggiornare, scaricare ed eseguire il nuovo installatore qui sotto.","win.32":"Download alternativi per sistemi a 32-bit:","win.download":"Scarica per Windows (64-bit)","win.help":"Se compare un avviso di Windows, clicca \"More info\" e poi \"Run anyways\""},
-  "ja":{"header.affiliation":"TurboWarpはScratch、Scratch Team、Scratch財団と提携していません。","header.subtitle":"コンパイラ、ダークモード、アドオンなどを備えたScratch MOD の{TurboWarp}をデスクトップ上で利用できます。オフラインでも動作します。","linux.snapTitle":"Snap Store で入手できます","picture.caption":"写真のプロジェクト: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"プロジェクトの写真: Full Sphere Path Tracer by piano_miles","privacy":"プライバシーポリシー","source":"ソースコード","update.linux":"アプリストアまたはSnapStoreなどのパッケージマネージャからTurboWarp Desktopをインストールした場合は、アップデートがストアに入るされるまで待って下さい。それ以外の場合は、以下の新規インストーラーを実行してください。","update.mac":"アップデートするには、以下の新しいアプリをダウンロードしてインストールしてください。","update.windows":"更新するには、以下の新しいインストーラーをダウンロードして実行します。"},
-  "ko":{"header.affiliation":"TurboWarp는 스크래치, 스크래치 팀,  스크래치 재단에 소속되지 않았습니다.","header.subtitle":"{TurboWarp}를 이용하여 오프라인일 때에도 당신의 컴퓨터에서 스크래치를 다크 모드, 컴파일러, 애드온과 같은 기능을 사용해 보세요.","linux.snapTitle":"Snap Store에서 받기","picture.caption":"프로젝트 캡쳐됨: {project}","picture.caption.project":"piano_miles의 \"Full Sphere Path Tracer\"","picture.title":"piano_miles의 \"Full Sphere Path Tracer\" 프로젝트의 캡쳐","privacy":"개인정보 보호 정책","source":"소스코드","update.linux":"SnapStore와 같은 앱 스토어 또는 패키지 관리자에서 TurboWarp 데스크탑을 설치한 경우 업데이트가 스토어에 올라올 때까지 기다립니다. 그렇지 않은 경우 아래에서 새 설치 프로그램을 실행하세요.","update.mac":"업데이트하려면, 아래의 새 앱을 다운로드하고 설치하세요.","update.windows":"업데이트하려면, 아래의 새 설치기를 다운로드하고 실행하세요."},
-  "nb":{"header.affiliation":"TurboWarp er ikke tilknyttet Scratch, Scratch-gruppen eller Scratch Foundation.","header.subtitle":"Bruk {TurboWarp}, Scratch-modet med kompilator, mørkt tema, utvidelser og mer, fra en app på din PC. Det fungerer også når du er offline."},
-  "pl":{"githubBugs":"Zgłoś błędy na GitHub","header.affiliation":"TurboWarp nie jest powiązany ze Scratch, Scratch Team, ani Scratch Foundation.","header.subtitle":"Używaj {TurboWarp}, mod Scratcha z kompilatorem, trybem ciemnym, dodatkami i nie tylko. Z aplikacji na pulpicie. Działa nawet, gdy jesteś offline.","linux.snapTitle":"Pobierz go ze sklepu Snap ","linux.terminal":"Uruchom to w terminalu","linux.uninstall":"Oinstaluj","mac.download":"Pobierz dla macOS (Uniwersalny)","mac.help":"Jeżeli pojawi się informacja Gatekeeper, otwórz Finder, przejdź do Aplikacji, prawym przyciskiem kliknij TurboWarp i wybierz \"Otwórz\" i \"Otwórz\" jeszcze raz.","picture.caption":"Projekt na zdjęciu: {project}","picture.caption.project":"Full Sphere Path Tracer autorstwa piano_miles","picture.title":"Pokazany projekt: Full Sphere Path Tracer autorstwa piano_miles","privacy":"Polityka prywatności","pwa.open":"Otwórz Stronę TurboWarp","scratchBugs":"Zgłoś błędy w Scratch","source":"Kod źródłowy","update.linux":"Jeśli zainstalowałeś TurboWarp Desktop ze sklepu z aplikacjami lub menedżera pakietów, takiego jak Snap Store, poczekaj, aż aktualizacja zostanie wypchnięta do sklepu. W przeciwnym razie uruchom nowy instalator poniżej.","update.mac":"Aby zaktualizować, pobierz i zainstaluj nową aplikację poniżej.","update.windows":"Aby zaktualizować, pobierz i uruchom nowy instalator poniżej.","win.32":"Alternatywne pobranie dla 32-bitowych systemów","win.download":"Pobierz dla Windowsa (64-bit)","win.help":"Jeżeli pojawi się alert Windows SmartScreen, kliknij „Więcej informacji”, a następnie „Uruchom mimo wszystko”."},
-  "pt":{"header.affiliation":"O TurboWarp não tem afiliação com o Scratch, a Equipe do Scratch ou a Fundação Scratch.","header.subtitle":"Use o {TurboWarp}, o mod do Scratch com um compilador, modo escuro, addons, e mais, em um app no seu computador. Até funciona sem internet.","linux.snapTitle":"Baixe pela Snap Store","picture.caption":"Projeto na imagem: {project}","picture.caption.project":"Full Sphere Path Tracer por piano_miles","picture.title":"Projeto na imagem: Full Sphere Path Tracer por piano_miles","privacy":"Política de privacidade","source":"Código-fonte","update.linux":"Se você instalou o TurboWarp Desktop de uma loja de aplicativo ou administrador de pacote como a Snap Store, espere até a atualização ser publicada na loja. Senão, rode o novo instalador abaixo.","update.mac":"Para atualizar, baixe e execute o novo aplicativo abaixo.","update.windows":"Para atualizar, baixe e execute o novo instalador abaixo."},
-  "ro":{"header.affiliation":"TurboWarp nu este conectat cu Scratch, Echipa Scratch, sau Fundația Scratch."},
-  "ru":{"header.affiliation":"TurboWarp не связан с Scratch, Командой Scratch или Фондом Scratch .","header.subtitle":"Используйте {TurboWarp}, модификацию Scratch с компилятором, темным режимом, дополнения и многое другое из приложения на рабочем столе. Оно работает даже в офлайн-режиме.","linux.snapTitle":"Получите в Snap Store","picture.caption":"Изображённый проект: {project}","picture.caption.project":"Full Sphere Path Tracer от piano_miles","picture.title":"Изображённый проект: Full Sphere Path Tracer от piano_miles","privacy":"Политика конфиденциальности","source":"Исходный код","update.linux":"Если вы установили TurboWarp Desktop из магазина приложений или диспетчера пакетов, такого как Snap Store, дождитесь, пока обновление будет отправлено в магазин. В противном случае запустите новый установочный файл ниже.","update.mac":"Чтобы обновить, скачайте и установите приложение ниже.","update.windows":"Чтобы обновить, скачайте и запустите установочный файл ниже."},
-  "sl":{"header.affiliation":"TurboWarp ni povezan s Scratchem, skupino Scratch ali fundacijo Scratch.","header.subtitle":"Uporabljajte {TurboWarp}, spremenjeno različico Scratcha s prevajalnikom kode, temnim načinom, dodatki in drugimi funkcijami, kot aplikacijo na svojem računalniku. Deluje tudi brez internetne povezave.","linux.snapTitle":"Namestitev iz trgovine Snap Store","picture.caption":"Projekt na sliki: {project}","picture.caption.project":"Full Sphere Path Tracer avtorja piano_miles","picture.title":"Projekt na sliki: Full Sphere Path Tracer avtorja piano_miles","privacy":"Politika zasebnosti","source":"Izvirna koda","update.linux":"Če ste namestili TurboWarp Desktop s pomočjo trgovine z aplikacijami ali upravitelja paketov, kot je Snap Store, počakajte, dokler posodobitev ni na voljo v trgovini. Sicer zaženite nov namestitveni program spodaj.","update.mac":"Za posodobitev spodaj prenesite in namestite novo aplikacijo.","update.windows":"Za posodobitev spodaj prenesite nov namestitveni program."},
-  "sv":{"source":"Källkod"},
-  "tr":{"githubBugs":"Hataları GitHub'da bildir","header.affiliation":"TurboWarp, Scratch, Scratch Takım veya Scratch Vakıfı ile bağlantılı değildir.","header.subtitle":"{TurboWarp}'u kullan, bir derleyici olan Scratch modu, karanlık modu, eklentiler ve çevrimdışı olduğunuzda bile çalışır.","linux.anywhere":"Tüm dağıtımlarda çalışır.","linux.choices":"Linux kullanıcılarının bazı seçenekleri vardır.","linux.snapTitle":"Snap Storundan alın","linux.terminal":"Bunu bir terminalde çalıştır","linux.uninstall":"Kaldır","mac.download":"macOS için İndir (Evrensel)","mac.help":"Eğer bir Gatekeeper iletisi gözükürse, Finder'ı açın, Uygulamalar kısmına gidin, TurboWarp'a sağ tıklayın ve \"Aç\" tuşunu seçin, ardından tekrar \"Aç\" tuşuna basın.","picture.caption":"Fotoğrafta gösterilen proje: {project}","picture.caption.project":"Full Sphere Path Tracer by piano_miles","picture.title":"Fotoğrafta gösterilen proje: piano_miles tarafından Full Sphere Path Tracer","privacy":"Gizillik politikası","pwa.help":"Daha sonra URL'deki indir butonuna bas. Görünmesi birkaç saniye alabilir.","pwa.open":"TurboWarp Websitesi'ni Aç","scratchBugs":"Hataları Scratch'te bildir","source":"Kaynak kodu","update.linux":"Eğer Turbowarp Desktop'u bir uygulama mağazasından örneğin Snap Store indirirsen, güncelleme mağazaya aktarılana kadar bekleyin. Aksi takdirde, aşağıdaki yeni yükleyiciyi çalıştırın.","update.mac":"Güncellemek için, yeni yükleyiciği aşağıda indirin.","update.windows":"Güncellemek için, yeni yükleyiciği aşağıda çalıştır.","win.32":"32-bit sistemler için alternatif indirme","win.download":"Windows için İndir (64-bit)","win.help":"Eğer bir Windows SmartScreen uyarısı gözükürse, \"Daha fazla bilgi\" ve ardından \"Yine de çalıştır\" tuşlarına basınız."},
-  "zh-cn":{"header.affiliation":"TurboWarp 不属于 Scratch、Scratch 团队或 Scratch 基金会。","header.subtitle":"在你的电脑上使用 {TurboWarp}，一个拥有编译器、深色模式、插件等功能的 Scratch 修改版。它甚至还能在你离线的时候运行。","linux.snapTitle":"从 Snap Store 获取","picture.caption":"图片中的作品：{project}","picture.caption.project":"由 piano_miles 制作的 Full Sphere Path Tracer","picture.title":"图片中的作品：由 piano_miles 制作的 Full Sphere Path Tracer","privacy":"隐私政策","source":"源代码","update.linux":"如果你从像 Snap Store 一样的应用商店或包管理器安装了 TurboWarp Desktop，请等待更新推送到该商店。否则，请运行下面的新安装程序。","update.mac":"在下面下载并安装新的应用程序以更新。","update.windows":"在下面下载并运行新的安装程序以更新。"},
-  "zh-tw":{"header.affiliation":"TurboWarp 並不隸屬於 Scratch、Scratch 團隊或 Scratch 基金會。","header.subtitle":"{TurboWarp}，運行更快且帶有黑暗模式、附加元件及其他好用功能的 Scratch，可在電腦和手機上使用，離線亦然。","linux.snapTitle":"從 Snap Store 安裝","picture.caption":"上圖專案：{project}","picture.caption.project":"Full Sphere Path Tracer，作者：piano_miles","picture.title":"上圖專案：Full Sphere Path Tracer，作者：piano_miles","privacy":"隱私政策","source":"原始碼","update.linux":"若你是從應用商店或軟體套件管理系統（如 Snap Store）安裝 TurboWarp 的，就必須等到它放上更新。或者，運行下方的安裝程式。","update.mac":"下載並安裝新版程式以更新。","update.windows":"下載並運行下方的新版安裝程式以更新。"},
-  }/*===*/;
-
-          const translatableElements = document.querySelectorAll('[data-l10n]');
-          const translatableAttributes = document.querySelectorAll('[data-l10n-attrib]');
-
-          function getId(el) {
-            if (el.getAttribute('data-l10n-subkey')) return el.getAttribute('data-l10n-subkey');
-            return el.textContent.trim().replace(/\s+/g, '_').replace(/[^a-z_0-9]/gi, '') || ('placeholder' + j);
+            const messageParts = message.split(/{|}/g);
+            for (let i = 0; i < messageParts.length; i++) {
+              const part = messageParts[i];
+              if (i % 2 === 0) {
+                el.appendChild(document.createTextNode(part));
+              } else {
+                const node = namedNodes[part];
+                if (!node) {
+                  console.warn('Missing named node: ' + part);
+                  continue;
+                }
+                el.appendChild(node);
+              }
+            }
           }
 
-          function translate(language) {
-            if (!allLanguageMessages[language]) language = language.split('-')[0];
-            const messages = allLanguageMessages[language];
-            if (!messages) return;
-            document.documentElement.lang = language;
-
-            for (const el of translatableElements) {
-              const nodes = el.childNodes;
-              const namedNodes = {};
-              const key = el.getAttribute('data-l10n');
+          for (const el of translatableAttributes) {
+            for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
               const message = messages[key];
-
               if (!message) {
                 console.warn('Missing message: ' + key);
                 continue;
               }
+              el.setAttribute(attribute, message);
+            }
+          }
+        }
 
-              for (const node of nodes) {
-                if (node.nodeName === '#text') continue;
+        function genl10n() {
+          const result = {};
+          for (const el of translatableElements) {
+            const nodes = el.childNodes;
+            const key = el.getAttribute('data-l10n');
+
+            let translationString = '';
+            let textNodes = 0;
+            for (let i = 0; i < nodes.length; i++) {
+              const node = nodes[i];
+              let nodeText = node.textContent;
+              nodeText = nodeText.replace(/^\s+/, i === 0 ? '' : ' ');
+              nodeText = nodeText.replace(/\s+$/, i === nodes.length - 1 ? '' : ' ');
+              if (node.nodeName === '#text') {
+                translationString += nodeText;
+                textNodes++;
+              } else {
                 const id = getId(node);
-                namedNodes[id] = node;
-                const message = messages[key + '.' + id];
-                if (message) {
-                  node.textContent = message;
-                }
-              }
-
-              while (el.firstChild) el.removeChild(el.firstChild);
-
-              const messageParts = message.split(/{|}/g);
-              for (let i = 0; i < messageParts.length; i++) {
-                const part = messageParts[i];
-                if (i % 2 === 0) {
-                  el.appendChild(document.createTextNode(part));
-                } else {
-                  const node = namedNodes[part];
-                  if (!node) {
-                    console.warn('Missing named node: ' + part);
-                    continue;
-                  }
-                  el.appendChild(node);
+                translationString += '{' + id + '}';
+                if (node.getAttribute('data-notranslate') === null) {
+                  result[key + '.' + id] = nodeText;
                 }
               }
             }
-
-            for (const el of translatableAttributes) {
-              for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
-                const message = messages[key];
-                if (!message) {
-                  console.warn('Missing message: ' + key);
-                  continue;
-                }
-                el.setAttribute(attribute, message);
-              }
+            if (result[key] && result[key] !== translationString) {
+              console.warn('Mismatch: ' + key);
+            }
+            result[key] = translationString;
+            if (textNodes === 0) {
+              console.warn('No text nodes: ' + key);
             }
           }
 
-          function genl10n() {
-            const result = {};
-            for (const el of translatableElements) {
-              const nodes = el.childNodes;
-              const key = el.getAttribute('data-l10n');
-
-              let translationString = '';
-              let textNodes = 0;
-              for (let i = 0; i < nodes.length; i++) {
-                const node = nodes[i];
-                let nodeText = node.textContent;
-                nodeText = nodeText.replace(/^\s+/, i === 0 ? '' : ' ');
-                nodeText = nodeText.replace(/\s+$/, i === nodes.length - 1 ? '' : ' ');
-                if (node.nodeName === '#text') {
-                  translationString += nodeText;
-                  textNodes++;
-                } else {
-                  const id = getId(node);
-                  translationString += '{' + id + '}';
-                  if (node.getAttribute('data-notranslate') === null) {
-                    result[key + '.' + id] = nodeText;
-                  }
-                }
-              }
-              if (result[key] && result[key] !== translationString) {
+          for (const el of translatableAttributes) {
+            for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
+              const text = el.getAttribute(attribute);
+              if (result[key] && result[key] !== text) {
                 console.warn('Mismatch: ' + key);
               }
-              result[key] = translationString;
-              if (textNodes === 0) {
-                console.warn('No text nodes: ' + key);
-              }
-            }
-
-            for (const el of translatableAttributes) {
-              for (const [attribute, key] of el.getAttribute('data-l10n-attrib').split(',').map((i) => i.split('='))) {
-                const text = el.getAttribute(attribute);
-                if (result[key] && result[key] !== text) {
-                  console.warn('Mismatch: ' + key);
-                }
-                result[key] = text;
-              }
-            }
-
-            document.body.appendChild(Object.assign(document.createElement('a'), {
-              href: URL.createObjectURL(new Blob([JSON.stringify(result)])),
-              download: 'desktop-web.json'
-            })).click();
-
-            return result;
-          }
-
-          return {
-            translate,
-            genl10n
-          };
-        })();
-        L.translate(navigator.language.toLowerCase());
-      </script>
-      <script>
-        (function() {
-          var VERSION = '0.9.0';
-
-          function getOS() {
-            if (/android/i.test(navigator.userAgent)) return 'windows';
-            if (/iphone|ipad|ipod/i.test(navigator.userAgent)) return 'windows';
-            if (/linux/i.test(navigator.userAgent)) return 'linux';
-            if (/cros/i.test(navigator.userAgent)) return 'chrome';
-            if (/mac/i.test(navigator.userAgent)) return 'mac';
-            return 'windows';
-          }
-          function setOS(os) {
-            document.body.setAttribute('os', os);
-          }
-
-          document.querySelector('.os-button-windows').addEventListener('click', function () {
-            setOS('windows');
-          });
-          document.querySelector('.os-button-mac').addEventListener('click', function () {
-            setOS('mac');
-          });
-          document.querySelector('.os-button-linux').addEventListener('click', function () {
-            setOS('linux');
-          });
-          document.querySelector('.os-button-chrome').addEventListener('click', function () {
-            setOS('chrome');
-          });
-
-          var links = document.querySelectorAll('a[data-href]');
-          for (var i = 0; i < links.length; i++) {
-            links[i].href = links[i].getAttribute('data-href').replace(/{version}/g, VERSION);
-          }
-          var versionTexts = document.querySelectorAll('.version-text');
-          for (var i = 0; i < versionTexts.length; i++) {
-            versionTexts[i].textContent = versionTexts[i].textContent.replace(/{version}/g, VERSION);
-          }
-
-          var images = document.querySelectorAll('img[data-src]');
-          var observer = window.IntersectionObserver && new IntersectionObserver(function (entries) {
-            for (var i = 0; i < entries.length; i++) {
-              var entry = entries[i];
-              if (entry.isIntersecting && !entry.target.src) {
-                entry.target.src = entry.target.getAttribute('data-src');
-              }
-            }
-          }, {
-            rootMargin: '50px'
-          });
-          for (var i = 0; i < images.length; i++) {
-            if (observer) {
-              observer.observe(images[i]);
-            } else {
-              images[i].src = images[i].getAttribute('data-src');
+              result[key] = text;
             }
           }
 
-          if (/from|to|changelog/i.test(location.search)) {
-            document.body.setAttribute('changelog', 'true');
-            document.getElementById('select-os').scrollIntoView();
-          }
+          document.body.appendChild(Object.assign(document.createElement('a'), {
+            href: URL.createObjectURL(new Blob([JSON.stringify(result)])),
+            download: 'desktop-web.json'
+          })).click();
 
-          setOS(getOS());
-          document.body.setAttribute('loaded', '');
-        }());
-      </script>
-    </body>
-  </html>
+          return result;
+        }
+
+        return {
+          translate,
+          genl10n
+        };
+      })();
+      L.translate(navigator.language.toLowerCase());
+    </script>
+    <script>
+      (function() {
+        var VERSION = '0.9.0';
+
+        function getOS() {
+          if (/android/i.test(navigator.userAgent)) return 'windows';
+          if (/iphone|ipad|ipod/i.test(navigator.userAgent)) return 'windows';
+          if (/linux/i.test(navigator.userAgent)) return 'linux';
+          if (/cros/i.test(navigator.userAgent)) return 'chrome';
+          if (/mac/i.test(navigator.userAgent)) return 'mac';
+          return 'windows';
+        }
+        function setOS(os) {
+          document.body.setAttribute('os', os);
+        }
+
+        document.querySelector('.os-button-windows').addEventListener('click', function () {
+          setOS('windows');
+        });
+        document.querySelector('.os-button-mac').addEventListener('click', function () {
+          setOS('mac');
+        });
+        document.querySelector('.os-button-linux').addEventListener('click', function () {
+          setOS('linux');
+        });
+        document.querySelector('.os-button-chrome').addEventListener('click', function () {
+          setOS('chrome');
+        });
+
+        var links = document.querySelectorAll('a[data-href]');
+        for (var i = 0; i < links.length; i++) {
+          links[i].href = links[i].getAttribute('data-href').replace(/{version}/g, VERSION);
+        }
+        var versionTexts = document.querySelectorAll('.version-text');
+        for (var i = 0; i < versionTexts.length; i++) {
+          versionTexts[i].textContent = versionTexts[i].textContent.replace(/{version}/g, VERSION);
+        }
+
+        var images = document.querySelectorAll('img[data-src]');
+        var observer = window.IntersectionObserver && new IntersectionObserver(function (entries) {
+          for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            if (entry.isIntersecting && !entry.target.src) {
+              entry.target.src = entry.target.getAttribute('data-src');
+            }
+          }
+        }, {
+          rootMargin: '50px'
+        });
+        for (var i = 0; i < images.length; i++) {
+          if (observer) {
+            observer.observe(images[i]);
+          } else {
+            images[i].src = images[i].getAttribute('data-src');
+          }
+        }
+
+        if (/from|to|changelog/i.test(location.search)) {
+          document.body.setAttribute('changelog', 'true');
+          document.getElementById('select-os').scrollIntoView();
+        }
+
+        setOS(getOS());
+        document.body.setAttribute('loaded', '');
+      }());
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
The download buttons are now of the same style as all the other buttons on the page, instead of the retro gradient glossy things. The link for 32-bit windows downloads has been turned into a second button.

The period in the text "It even works when you're offline." has been changed to an exclamation mark.

<sub><sup>Hmm... Github thinks I've deleted 728 lines and added 735, though I really haven't.</sub></sup>