### PR TITLE
Update to electron 19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,15 +63,12 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         npx electron-builder --linux deb --x64 --publish always
-        npx electron-builder --linux deb --ia32 --publish always
         npx electron-builder --linux deb --arm64 --publish always
         npx electron-builder --linux deb --armv7l --publish always
         npx electron-builder --linux tar.gz --x64 --publish always
-        npx electron-builder --linux tar.gz --ia32 --publish always
         npx electron-builder --linux tar.gz --arm64 --publish always
         npx electron-builder --linux tar.gz --armv7l --publish always
         npx electron-builder --linux AppImage --x64 --publish always
-        npx electron-builder --linux AppImage --ia32 --publish always
         npx electron-builder --linux AppImage --arm64 --publish always
         npx electron-builder --linux AppImage --armv7l --publish always
       env:

--- a/docs/index.html
+++ b/docs/index.html
@@ -587,7 +587,6 @@
         <h2>.deb</h2>
         <ul>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-amd64-{version}.deb">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.deb">x86 32-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.deb">ARM 64-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.deb">ARMv7l</a></li>
         </ul>
@@ -598,7 +597,6 @@
         <h2>.AppImage</h2>
         <ul>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x86_64-{version}.AppImage">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-i386-{version}.AppImage">x86 32-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.AppImage">ARM 64-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.AppImage">ARMv7l</a></li>
         </ul>
@@ -606,7 +604,6 @@
         <h2>.tar.gz</h2>
         <ul>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-x64-{version}.tar.gz">x86 64-bit</a></li>
-          <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-ia32-{version}.tar.gz">x86 32-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-arm64-{version}.tar.gz">ARM 64-bit</a></li>
           <li><a data-href="https://github.com/TurboWarp/desktop/releases/download/v{version}/TurboWarp-linux-armv7l-{version}.tar.gz">ARMv7l</a></li>
         </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5595,12 +5595,12 @@
       }
     },
     "electron": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.1.tgz",
-      "integrity": "sha512-46lH3iEdvbbDSa0s2JiOysGruQlJwGUae0UrEfZ4NgHZUnHbglkvezfKSoRSOEob3c9rENZlvgEv9gCbhYx5Yw==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.1.tgz",
+      "integrity": "sha512-zuhJVV7nTDFrRZ7uAIylSD0Eoi1xcUV4UzGfpWsREI4W5GsxNGyZQeqQDpg43w8+7oED812oDrGfPh5kb9rcQA==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-react": "^7.13.13",
     "@turbowarp/electron-webpack": "^2.9.1",
     "css-loader": "^5.0.2",
-    "electron": "^18.3.1",
+    "electron": "^19.0.1",
     "electron-builder": "^23.0.9",
     "intl-messageformat": "^9.4.7",
     "postcss": "^8.4.13",


### PR DESCRIPTION
Notably, this removes support for 32-bit x86 Linux builds. Many modern Linux distributions have already dropped support for this platform. Neither our Flatpak or Snap builds supported this platform either. Looking at https://desktop.turbowarp.org/stats.html it doesn't seem like we have many active users on this platform anyways.
