### PR TITLE
Implement project tokens for CLI

### DIFF
--- a/src/renderer/gui/gui.jsx
+++ b/src/renderer/gui/gui.jsx
@@ -16,6 +16,7 @@ import AddonChannels from 'scratch-gui/src/addons/channels';
 import {WrappedFileHandle} from './filesystem-api-impl';
 import {localeChanged, getTranslation} from '../translations';
 import runAddons from 'scratch-gui/src/addons/entry';
+import loadInitialProject from './load-initial-project';
 import './gui.css';
 
 class StorageHelper {
@@ -86,29 +87,6 @@ const getProjectTitle = (file) => {
   return match[1];
 };
 
-const isValidURL = (url) => {
-  try {
-    const u = new URL(url);
-    return u.protocol === 'https:' || u.protocol === 'http:';
-  } catch (e) {
-    return false;
-  }
-};
-
-const fetchProjectFromURL = (url) => ipcRenderer.invoke('request-url', url);
-
-const readInitialFile = async () => {
-  if (isValidURL(fileToOpen)) {
-    const match = fileToOpen.match(/^https:\/\/scratch\.mit\.edu\/projects\/(\d+)\/?$/);
-    if (match) {
-      const id = match[1];
-      return fetchProjectFromURL(`https://projects.scratch.mit.edu/${id}`);
-    }
-    return fetchProjectFromURL(fileToOpen);
-  }
-  return ipcRenderer.invoke('read-file', fileToOpen);
-};
-
 const readBlobAsArrayBuffer = (blob) => new Promise((resolve, reject) => {
   const fr = new FileReader();
   fr.onload = () => resolve(fr.result);
@@ -148,7 +126,7 @@ const DesktopHOC = function (WrappedComponent) {
         this.props.onLoadingCompleted();
       } else {
         this.props.onHasInitialProject(true, this.props.loadingState);
-        readInitialFile()
+        loadInitialProject(fileToOpen)
           .then((projectData) => {
             return this.props.vm.loadProject(projectData)
           })

--- a/src/renderer/gui/load-initial-project.js
+++ b/src/renderer/gui/load-initial-project.js
@@ -1,0 +1,69 @@
+import {ipcRenderer} from 'electron';
+
+const isValidURL = (url) => {
+  try {
+    const u = new URL(url);
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * @param {string} path Path to rad
+ * @returns {Promise<ArrayBuffer>}
+ */
+const readFileFromMainThread = (path) => ipcRenderer.invoke('read-file', path);
+
+/**
+ * @param {string} url URL to fetch
+ * @returns {Promise<ArrayBuffer>}
+ */
+const requestFromMainThreadAsArrayBuffer = (url) => ipcRenderer.invoke('request-url', url);
+
+const requestFromMainThreadAsJSON = async (url) => {
+  const buffer = await requestFromMainThreadAsArrayBuffer(url);
+  const text = new TextDecoder().decode(buffer);
+  const json = JSON.parse(text);
+  return json;
+};
+
+const getScratchProjectID = (url) => {
+  const match = url.match(/^https:\/\/scratch\.mit\.edu\/projects\/(\d+)\/?$/);
+  return match ? match[1] : null;
+};
+
+const fetchScratchProject = async (id) => {
+  // We are a desktop app, so we can make requests directly to the Scratch API.
+  let token = null;
+  try {
+    // api.scratch.mit.edu has strict CORS that we can't fetch by default, so make the main thread do it
+    const projectMetadata = await requestFromMainThreadAsJSON(`https://api.scratch.mit.edu/projects/${id}`);
+    token = projectMetadata.project_token;
+  } catch (e) {
+    // For now, this error is non-critical.
+    console.error(e);
+  }
+
+  const tokenPart = token ? `?token=${token}` : '';
+  const url = `https://projects.scratch.mit.edu/${id}${tokenPart}`;
+  // projects.scratch.mit.edu currently does not have strict CORS
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Request for project ID ${id} returned status ${r.status}`);
+  }
+  return res.arrayBuffer();
+};
+
+const loadInitialProject = async (pathOrURL) => {
+  if (isValidURL(pathOrURL)) {
+    const projectId = getScratchProjectID(pathOrURL);
+    if (projectId) {
+      return fetchScratchProject(projectId);
+    }
+    return requestFromMainThreadAsArrayBuffer(pathOrURL);
+  }
+  return readFileFromMainThread(pathOrURL);
+};
+
+export default loadInitialProject;

--- a/src/renderer/gui/load-initial-project.js
+++ b/src/renderer/gui/load-initial-project.js
@@ -29,7 +29,7 @@ const requestFromMainThreadAsJSON = async (url) => {
 };
 
 const getScratchProjectID = (url) => {
-  const match = url.match(/^https:\/\/scratch\.mit\.edu\/projects\/(\d+)\/?$/);
+  const match = url.match(/^https?:\/\/scratch\.mit\.edu\/projects\/(\d+)\/?/);
   return match ? match[1] : null;
 };
 


### PR DESCRIPTION
Closes #398 

Because we are a desktop app, we can directly talk to api.scratch.mit.edu instead of going through trampoline.
