### PR TITLE
Create separate release builds for Intel Silicon and Apple Silicon macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,8 @@ jobs:
     - name: Package macOS
       if: runner.os == 'macOS'
       run: |
-        npx electron-builder --mac dmg --universal --publish always
+        npx electron-builder --mac dmg --x64 --publish always
+        npx electron-builder --mac dmg --arm64 --publish always
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       "allowToChangeInstallationDirectory": true
     },
     "mac": {
-      "artifactName": "${productName} Setup ${version}.${ext}",
+      "artifactName": "${productName} Setup ${version} ${arch}.${ext}",
       "icon": "build/icon.icns",
       "category": "public.app-category.education",
       "darkModeSupport": true,


### PR DESCRIPTION
Closes #405

Compressed builds are 70MB smaller (200MB -> 130MB). Uncompressed size after installation is 172MB smaller (426MB -> 254MB). This is worthwhile.

Will need website changes after release.