### PR TITLE
Convert some security manager logic to Electron permission checks

### DIFF
--- a/src-main/l10n/en.json
+++ b/src-main/l10n/en.json
@@ -358,5 +358,37 @@
   "files.zip": {
     "string": "Zip File",
     "context": "Appears in file saving dialog when saving some types of packaged projects"
+  },
+  "security-prompt.title": {
+    "string": "Extension Security",
+    "context": "Title of extension security prompt window"
+  },
+  "security-prompt.allow": {
+    "string": "Allow",
+    "context": "Title of extension security prompt window. This button allows the permission."
+  },
+  "security-prompt.deny": {
+    "string": "Deny",
+    "context": "Title of extension security prompt window. This button denies the permission."
+  },
+  "security-prompt.read-clipboard1": {
+    "string": "The project wants to read data from your clipboard.",
+    "context": "Part of the extension security prompt window"
+  },
+  "security-prompt.read-clipboard2": {
+    "string": "If your clipboard contains things like passwords, the project may be able to share those with other users or servers.",
+    "context": "Part of the extension security prompt window"
+  },
+  "security-prompt.read-clipboard3": {
+    "string": "Clipboard access may not work on some systems. If allowed, further clipboard reads will be automatically allowed.",
+    "context": "Part of the extension security prompt window"
+  },
+  "security-prompt.notifications1": {
+    "string": "The project wants to display notifications.",
+    "context": "Part of the extension security prompt window"
+  },
+  "security-prompt.notifications2": {
+    "string": "If allowed, you may be prompted to enable notifications by your operating system, and further notifications will be automatically allowed.",
+    "context": "Part of the extension security prompt window"
   }
 }

--- a/src-main/protocols.js
+++ b/src-main/protocols.js
@@ -35,7 +35,10 @@ const FILE_SCHEMES = {
     supportFetch: true
   },
   'tw-update': {
-    root: path.resolve(__dirname, '../src-renderer/update')
+    root: path.resolve(__dirname, '../src-renderer/update'),
+  },
+  'tw-security-prompt': {
+    root: path.resolve(__dirname, '../src-renderer/security-prompt'),
   }
 };
 

--- a/src-main/windows/packager-preview.js
+++ b/src-main/windows/packager-preview.js
@@ -4,7 +4,9 @@ const {translate} = require('../l10n');
 
 class PackagerPreviewWindow extends ProjectRunningWindow {
   constructor (parentWindow, existingWindow) {
-    super(existingWindow);
+    super({
+      existingWindow
+    });
 
     this.window.setBounds(BaseWindow.calculateWindowBounds(parentWindow.getBounds(), this.window.getBounds()));
 

--- a/src-main/windows/project-running-window.js
+++ b/src-main/windows/project-running-window.js
@@ -3,6 +3,7 @@ const path = require('path')
 const BaseWindow = require('./base');
 const settings = require('../settings');
 const askForMediaAccess = require('../media-permissions');
+const SecurityPromptWindow = require('./security-prompt');
 
 const listLocalFiles = async () => {
   const files = await fsPromises.readdir(path.join(__dirname, '../../dist-library-files/'));
@@ -39,6 +40,7 @@ class ProjectRunningWindow extends BaseWindow {
       permission === 'window-placement' ||
 
       // Notifications extension
+      // Actually displaying notifications also requires handlePermissionRequest check
       permission === 'notifications' ||
 
       // Custom fonts menu
@@ -60,6 +62,16 @@ class ProjectRunningWindow extends BaseWindow {
       return true;
     }
 
+    // Clipboard extension
+    if (permission === 'clipboard-read') {
+      return SecurityPromptWindow.requestReadClipboard(this.window);
+    }
+
+    // Notifications extension
+    if (permission === 'notifications') {
+      return SecurityPromptWindow.requestNotifications(this.window);
+    }
+
     return (
       // Enhanced fullscreen addon
       permission === 'fullscreen' ||
@@ -67,12 +79,9 @@ class ProjectRunningWindow extends BaseWindow {
       // Pointerlock extension and experiment
       permission === 'pointerLock' ||
 
-      // Notifications extension
-      permission === 'notifications' ||
-
       // Clipboard extension
-      permission === 'clipboard-sanitized-write' ||
-      permission === 'clipboard-read'
+      // Writing is safer than reading
+      permission === 'clipboard-sanitized-write'
     );
   }
 

--- a/src-main/windows/security-prompt.js
+++ b/src-main/windows/security-prompt.js
@@ -1,0 +1,156 @@
+const BaseWindow = require('./base');
+const {APP_NAME} = require('../brand');
+const {translate, getLocale, getStrings} = require('../l10n');
+
+class SecurityState {
+  constructor () {
+    this.allowedReadClipboard = false;
+    this.allowedNotifications = false;
+
+    this._isPromptLocked = false;
+    this._queuedPromptCallbacks = [];
+  }
+
+  acquirePromptLock () {
+    let released = false;
+
+    const lock = {
+      releaseLock: () => {
+        // This should only be called once per lock, but since this is security sensitive, we'll still try to avoid
+        // letting this get into a bad state.
+        if (released) {
+          throw new Error('releaseLock() called twice');
+        }
+        released = true;
+
+        if (this._queuedPromptCallbacks.length === 0) {
+          this._isPromptLocked = false;
+        } else {
+          const nextCallback = this._queuedPromptCallbacks.shift();
+          nextCallback();
+        }
+      }
+    };
+
+    return new Promise((resolve) => {
+      if (this._isPromptLocked) {
+        this._queuedPromptCallbacks.push(() => resolve(lock));
+      } else {
+        this._isPromptLocked = true;
+        resolve(lock);
+      }
+    });
+  }
+
+  /**
+   * @private
+   * @type {WeakMap<Electron.BrowserWindow, SecurityState>}
+   */
+  static _windowMap = new WeakMap();
+
+  /**
+   * @param {Electron.BrowserWindow} window
+   * @returns {SecurityState}
+   */
+  static forWindow (window) {
+    if (!SecurityState._windowMap.has(window)) {
+      SecurityState._windowMap.set(window, new SecurityState());
+    }
+    return SecurityState._windowMap.get(window);
+  }
+}
+
+class SecurityPromptWindow extends BaseWindow {
+  /**
+   * @param {Electron.BrowserWindow} projectWindow
+   * @param {string} type
+   */
+  constructor (projectWindow, type) {
+    super({
+      parentWindow: projectWindow
+    });
+
+    /** @type {Promise<boolean>} */
+    this.promptPromise = new Promise((resolve) => {
+      this.promptResolve = resolve;
+    });
+
+    const ipc = this.window.webContents.ipc;
+
+    ipc.on('init', (event) => {
+      event.returnValue = {
+        type,
+        APP_NAME,
+        locale: getLocale(),
+        strings: getStrings()
+      };
+    });
+
+    ipc.handle('ready', (event, options) => {
+      const contentHeight = +options.height;
+
+      const [minWidth, minHeight] = this.window.getMinimumSize();
+      if (contentHeight < minHeight) {
+        this.window.setMinimumSize(minWidth, contentHeight);
+      }
+      this.window.setContentSize(this.getDimensions().width, contentHeight, false);
+
+      this.show();
+    });
+
+    ipc.handle('done', (event, allowed) => {
+      this.promptResolve(!!allowed);
+
+      // destroy() won't run the close event
+      this.window.destroy();
+    });
+
+    this.window.on('close', () => {
+      this.promptResolve(false);
+    });
+
+    this.window.setTitle(`${translate('security-prompt.title')} - ${APP_NAME}`);
+    this.loadURL('tw-security-prompt://./security-prompt.html');
+  }
+
+  getDimensions () {
+    return {
+      width: 440,
+      height: 320
+    };
+  }
+
+  getPreload () {
+    return 'security-prompt';
+  }
+
+  isPopup () {
+    return true;
+  }
+
+  done () {
+    return this.promptPromise;
+  }
+
+  static async requestReadClipboard (window) {
+    const state = SecurityState.forWindow(window);
+    if (!state.allowedReadClipboard) {
+      const {releaseLock} = await state.acquirePromptLock();
+      state.allowedReadClipboard = await new SecurityPromptWindow(window, 'read-clipboard').done();
+      releaseLock();
+    }
+    return state.allowedReadClipboard;  
+  }
+
+  static async requestNotifications (window) {
+    const state = SecurityState.forWindow(window);
+    if (!state.allowedNotifications) {
+      const {releaseLock} = await state.acquirePromptLock();
+      state.allowedNotifications = await new SecurityPromptWindow(window, 'notifications').done();
+      releaseLock();
+    }
+    return state.allowedNotifications;  
+  }
+}
+
+module.exports = SecurityPromptWindow;

--- a/src-preload/security-prompt.js
+++ b/src-preload/security-prompt.js
@@ -1,0 +1,8 @@
+const {contextBridge, ipcRenderer} = require('electron');
+
+contextBridge.exposeInMainWorld('SecurityPromptPreload', {
+  init: () => ipcRenderer.sendSync('init'),
+  ready: (options) => ipcRenderer.invoke('ready', options),
+  allow: () => ipcRenderer.invoke('done', true),
+  deny: () => ipcRenderer.invoke('done', false),
+});

--- a/src-renderer-webpack/editor/gui/desktop-hoc.jsx
+++ b/src-renderer-webpack/editor/gui/desktop-hoc.jsx
@@ -58,6 +58,17 @@ const handleClickDonate = () => {
   window.open('https://github.com/sponsors/GarboMuffin');
 };
 
+const securityManager = {
+  // Everything not specified here falls back to the scratch-gui security manager
+
+  // Managed by Electron main process:
+  canReadClipboard: () => true,
+  canNotify: () => true,
+
+  // Does not work in Electron:
+  canGeolocate: () => false
+};
+
 const USERNAME_KEY = 'tw:username';
 const DEFAULT_USERNAME = 'player';
 
@@ -212,7 +223,8 @@ const DesktopHOC = function (WrappedComponent) {
                 onClick: handleClickDonate
               }
             ])
-          ]}      
+          ]}
+          securityManager={securityManager}
           {...props}
         />
       );

--- a/src-renderer/security-prompt/security-prompt.html
+++ b/src-renderer/security-prompt/security-prompt.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+    <style>
+      :root {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        color: black;
+        background-color: white;
+      }
+      body {
+        padding: 0;
+        margin: 0;
+      }
+
+      main {
+        padding: 0.75rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      p {
+        margin: 0;
+      }
+
+      .buttons {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .buttons button {
+        flex-grow: 1;
+        font: inherit;
+        font-weight: bold;
+        padding: 0.75rem 1rem;
+        border-radius: 0.25rem;
+        border: rgba(0, 0, 0, 0.15);
+        cursor: pointer;
+      }
+      .deny {
+        background-color: rgb(255, 92, 92);
+        color: white;
+      }
+      .allow {
+        background-color: #24cd11;
+        color: black;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          background-color: #111;
+          color: #eee;
+        }
+        .buttons button {
+          border-color: rgba(255, 255, 255, 0.15);
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <p data-type="read-clipboard" data-l10n="security-prompt.read-clipboard1"></p>
+      <p data-type="read-clipboard" data-l10n="security-prompt.read-clipboard2"></p>
+      <p data-type="read-clipboard" data-l10n="security-prompt.read-clipboard3"></p>
+
+      <p data-type="notifications" data-l10n="security-prompt.notifications1"></p>
+      <p data-type="notifications" data-l10n="security-prompt.notifications2"></p>
+
+      <div class="buttons">
+        <button class="deny" disabled data-l10n="security-prompt.deny"></button>
+        <button class="allow" disabled data-l10n="security-prompt.allow"></button>
+      </div>
+    </main>
+
+    <script>
+      const {APP_NAME, locale, strings, type} = SecurityPromptPreload.init();
+      document.documentElement.lang = locale;
+
+      for (const el of document.querySelectorAll('[data-l10n]')) {
+        const stringName = el.getAttribute('data-l10n');
+        el.textContent = (strings[stringName] || `Missing string: ${stringName}`).replace('{APP_NAME}', APP_NAME);
+      }
+      for (const el of document.querySelectorAll('[data-type]')) {
+        if (el.getAttribute('data-type') !== type) {
+          el.style.display = 'none';
+        }
+      }
+ 
+      const allowButton = document.querySelector('.allow');
+      allowButton.addEventListener('click', () => {
+        SecurityPromptPreload.allow();
+      });
+
+      const denyButton = document.querySelector('.deny');
+      denyButton.addEventListener('click', () => {
+        SecurityPromptPreload.deny();
+      });
+
+      // Delay to prevent clickjacking
+      setTimeout(() => {
+        denyButton.disabled = false;
+        allowButton.disabled = false;
+      }, 500);
+
+      SecurityPromptPreload.ready({
+        height: document.body.clientHeight
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Endgame is to migrate all of security manager to main process permission checks as it is more secure and can't be bypassed by malicious extension JS

Starting with clipboard reading and notifications as they are relatively important security-wise and trivial to move over