### PR TITLE
Remove legacy data from pre-rewrite versions of the app to recover disk space

### DIFF
--- a/src-main/l10n/en.json
+++ b/src-main/l10n/en.json
@@ -283,6 +283,10 @@
     "string": "Finalizing...",
     "developer_comment": "Status message that appears while finishing an update."
   },
+  "migrate.delete-legacy": {
+    "string": "Deleting old data...",
+    "developer_comment": "Status message that appears while finishing an update. Old data refers to data stored by old versions of the app that is now redundant after updates."
+  },
   "update.window-title": {
     "string": "Update Available",
     "developer_comment": "Title of update available window"

--- a/src-main/l10n/en.json
+++ b/src-main/l10n/en.json
@@ -287,6 +287,18 @@
     "string": "Deleting old data...",
     "developer_comment": "Status message that appears while finishing an update. Old data refers to data stored by old versions of the app that is now redundant after updates."
   },
+  "migrate-future.message": {
+    "string": "It looks like you installed an older version of {APP_NAME} after using a later version. Downgrading is not guaranteed to be safe; you may lose data such as your settings and backpack. Please exit and download the latest version from {website}. (Debug info: {debugInfo})",
+    "developer_comment": "May appear when someone installs the latest version of the dekstop app, runs it, then installs and runs an older version. {APP_NAME} becomes 'TurboWarp Desktop'. {website} becomes a URL like 'desktop.turbowarp.org'. {debugInfo} becomes something like '2 < 3' (internal version numbers) to aid with debugging."
+  },
+  "migrate-future.exit": {
+    "string": "Exit and Update",
+    "developer_comment": "May appear when someone installs the latest version of the dekstop app, runs it, then installs and runs an older version. This button exits the app and opens the website for someone to download the latest version."
+  },
+  "migrate-future.continue-anyways": {
+    "string": "Continue Anyways (Unsafe)",
+    "developer_comment": "May appear when someone installs the latest version of the dekstop app, runs it, then installs and runs an older version. This button accepts the warning and will just continue anyways, hoping for the best."
+  },
   "update.window-title": {
     "string": "Update Available",
     "developer_comment": "Title of update available window"

--- a/src-main/migrate.js
+++ b/src-main/migrate.js
@@ -4,11 +4,13 @@ const path = require('path');
 const settings = require('./settings');
 const MigrateWindow = require('./windows/migrate');
 
-// This needs to run before the app is ready
-const userData = app.getPath('userData');
+// Avoid running migrate logic on fresh installs when we can. Not required, just helps
+// user experience. This must run before the ready event.
 const isFirstLaunch = (
   settings.dataVersion !== MigrateWindow.LATEST_VERSION &&
-  !fs.existsSync(path.join(userData, 'Cache'))
+  // Electron will always create the Cache directory in userData after the ready event,
+  // so if it doesn't exist yet, this is probably a fresh install.
+  !fs.existsSync(path.join(app.getPath('userData'), 'Cache'))
 );
 
 const migrate = async () => {

--- a/src-main/migrate.js
+++ b/src-main/migrate.js
@@ -1,8 +1,11 @@
-const {app} = require('electron');
+const {app, dialog} = require('electron');
 const fs = require('fs');
 const path = require('path');
 const settings = require('./settings');
 const MigrateWindow = require('./windows/migrate');
+const {APP_NAME} = require('./brand');
+const {translate} = require('./l10n');
+const safelyOpenExternal = require('./open-external');
 
 // Avoid running migrate logic on fresh installs when we can. Not required, just helps
 // user experience. This must run before the ready event.
@@ -14,6 +17,32 @@ const isFirstLaunch = (
 );
 
 const migrate = async () => {
+  if (settings.dataVersion > MigrateWindow.LATEST_VERSION) {
+    const result = dialog.showMessageBoxSync({
+      type: 'error',
+      title: APP_NAME,
+      message: translate('migrate-future.message')
+        .replace('{APP_NAME}', APP_NAME)
+        .replace('{website}', 'desktop.turbowarp.org')
+        .replace('{debugInfo}', `${MigrateWindow.LATEST_VERSION} < ${settings.dataVersion}`),
+      buttons: [
+        translate('migrate-future.exit'),
+        translate('migrate-future.continue-anyways')
+      ],
+      cancelId: 0,
+      defaultId: 0
+    });
+    if (result === 0) {
+      safelyOpenExternal('https://desktop.turbowarp.org/');
+      app.exit(1);
+    } else {
+      // Hope for the best!
+      settings.dataVersion = MigrateWindow.LATEST_VERSION;
+      await settings.save();
+      return;
+    }
+  }
+
   if (settings.dataVersion === MigrateWindow.LATEST_VERSION) {
     return;
   }

--- a/src-main/settings.js
+++ b/src-main/settings.js
@@ -60,7 +60,7 @@ class Settings {
   }
 
   get locale () {
-    return this.data.locale || 'es';
+    return this.data.locale || 'en';
   }
   set locale (locale) {
     this.data.locale = locale;

--- a/src-main/windows/migrate.js
+++ b/src-main/windows/migrate.js
@@ -8,7 +8,7 @@ const {APP_NAME} = require('../brand');
 const EMAIL = 'contact@turbowarp.org';
 
 class MigrateWindow extends BaseWindow {
-  static LATEST_VERSION = 3;
+  static LATEST_VERSION = 2;
 
   constructor () {
     super();

--- a/src-main/windows/migrate.js
+++ b/src-main/windows/migrate.js
@@ -8,10 +8,12 @@ const {APP_NAME} = require('../brand');
 const EMAIL = 'contact@turbowarp.org';
 
 class MigrateWindow extends BaseWindow {
-  static LATEST_VERSION = 2;
+  static LATEST_VERSION = 3;
 
   constructor () {
     super();
+
+    const oldDataVersion = settings.dataVersion;
 
     this.promise = new Promise((resolve) => {
       this.resolveCallback = resolve;
@@ -19,8 +21,9 @@ class MigrateWindow extends BaseWindow {
 
     const ipc = this.window.webContents.ipc;
 
-    ipc.on('get-strings', (event) => {
+    ipc.on('get-info', (event) => {
       event.returnValue = {
+        oldDataVersion,
         locale: getLocale(),
         strings: getStrings()
       };

--- a/src-preload/migrate.js
+++ b/src-preload/migrate.js
@@ -1,7 +1,7 @@
 const {contextBridge, ipcRenderer} = require('electron');
 
 contextBridge.exposeInMainWorld('MigratePreload', {
-  getStrings: () => ipcRenderer.sendSync('get-strings'),
+  getInfo: () => ipcRenderer.sendSync('get-info'),
   done: () => ipcRenderer.invoke('done'),
   continueAnyways: () => ipcRenderer.invoke('continue-anyways')
 });

--- a/src-renderer/migrate/migrate.html
+++ b/src-renderer/migrate/migrate.html
@@ -290,6 +290,9 @@
               } else if (type === 'error') {
                 reject(e.data.error);
               } else if (type === 'done') {
+                if (backpackDB) {
+                  backpackDB.close();
+                }
                 resolve();
               }
             } catch (e) {
@@ -341,6 +344,9 @@
               } else if (type === 'error') {
                 reject(e.data.error);
               } else if (type === 'done') {
+                if (blobDB) {
+                  blobDB.close();
+                }
                 resolve();
               }
             } catch (e) {

--- a/src-renderer/migrate/migrate.html
+++ b/src-renderer/migrate/migrate.html
@@ -152,7 +152,7 @@
       TW_AutoSave -> abandon (likely to be very large)
       */
 
-      const {strings, locale} = MigratePreload.getStrings();
+      const {oldDataVersion, strings, locale} = MigratePreload.getInfo();
       document.documentElement.lang = locale;
 
       document.querySelector('.title').textContent = strings['migrate.title'];
@@ -360,6 +360,31 @@
         });
       };
 
+      const deleteDatabase = (databaseName) => new Promise((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(databaseName);
+        request.onerror = () => {
+          reject(new Error(`Failed to delete IDB database ${databaseName}: ${request.error}`));
+        };
+        request.onsuccess = () => {
+          resolve();
+        };
+      });
+
+      const deleteLegacyData = async () => {
+        localStorage.clear();
+        sessionStorage.clear();
+
+        for (let i = 0; i < databases.length; i++) {
+          await deleteDatabase(databases[i].name);
+
+          // i starts from 0, so add 1 for the database we just deleted
+          setStepProgress(i + 1, databases.length);
+
+          // Give the browser some time to clean up; deleting large databases might be intensive
+          await new Promise((resolve) => setTimeout(resolve, 250))
+        }
+      };
+
       const finish = async () => {
         await MigratePreload.done();
       };
@@ -423,11 +448,16 @@
 
         await runStep(strings['migrate.preparing'], gatherMetadata);
 
-        if (!anyError) {
-          // Preparing must succeed for both of these, but each of these can fail
-          // independently.
+        if (!anyError && oldDataVersion < 2) {
+          // V2: Migrate data from file:// to tw-*://
+          // Preparing must succeed for both of these, but each can fail independently.
           await runStep(strings['migrate.transfer-editor'], migrateEditor);
           await runStep(strings['migrate.transfer-packager'], migratePackager);
+        }
+
+        if (!anyError && oldDataVersion < 3) {
+          // V3: Removing leftover data on file://
+          await runStep(strings['migrate.delete-legacy'], deleteLegacyData);
         }
 
         if (!anyError) {


### PR DESCRIPTION
Some people had hundreds of MB of data in the old version which were successfully migrated. However that old data is still there, taking up disk space.

At the time that was intentional as the migration logic was untested at scale, but now it's known to be mature, so it's safe to remove the old data too.