### PR TITLE
Update Winget Releaser action link

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: GarboMuffin.TurboWarp
           installers-regex: 'TurboWarp-Setup-[\d.]+-\w+\.exe$'


### PR DESCRIPTION
Action has moved from [`vedantmgoyal2009/winget-releaser@v2`](https://github.com/vedantmgoyal2009/winget-releaser) to 
 [`vedantmgoyal9/winget-releaser@main`](https://github.com/vedantmgoyal9/winget-releaser) (should fix some recent workflow failures as well).