### PR TITLE
Update to Electron 34

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
         # @electron/notaraize documentation says key should be an absolute path
         export APPLE_API_KEY="$(pwd)/$APPLE_API_KEY_NAME"
         node release-automation/build.js --mac --universal --production
-        node release-automation/build.js --mac-legacy-10.13-10.14 --x64 --production
+        # These macOS versions never ran on an Apple Silicon device, so only need x64
+        node release-automation/build.js --mac-legacy-10.13-10.14 --mac-legacy-10.15 --x64 --production
         # for safety
         rm "$APPLE_API_KEY_NAME"
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "copy-webpack-plugin": "^6.4.1",
         "cross-env": "^7.0.3",
         "css-loader": "^1.0.1",
-        "electron": "^32.3.0",
+        "electron": "^34.1.0",
         "electron-builder": "^26.0.0",
         "file-loader": "^6.2.0",
         "postcss": "^8.4.13",
@@ -7103,9 +7103,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "32.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.3.0.tgz",
-      "integrity": "sha512-CyX6K1INQdlgTePmP3wuAueUi5ePqw0IpiGOyyzULGU9gBQI3idwW6apR3W/R1cES2j1gWLrkty3cD40qRV9sg==",
+      "version": "34.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-34.1.0.tgz",
+      "integrity": "sha512-ZUid8XrGPA0dfes97PPADc8ecWOUX/qYRNp1glze9coZLEYc+PsMvgjVDCHSvjfHfiI+V3unwngSVpBouX71YQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "copy-webpack-plugin": "^6.4.1",
         "cross-env": "^7.0.3",
         "css-loader": "^1.0.1",
-        "electron": "^34.1.0",
+        "electron": "^34.2.0",
         "electron-builder": "^26.0.7",
         "file-loader": "^6.2.0",
         "postcss": "^8.4.13",
@@ -6948,9 +6948,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "34.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-34.1.0.tgz",
-      "integrity": "sha512-ZUid8XrGPA0dfes97PPADc8ecWOUX/qYRNp1glze9coZLEYc+PsMvgjVDCHSvjfHfiI+V3unwngSVpBouX71YQ==",
+      "version": "34.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-34.2.0.tgz",
+      "integrity": "sha512-SYwBJNeXBTm1q/ErybQMUBZAYqEreBUqBwTrNkw1rV4YatDZk5Aittpcus3PPeC4UoI/tqmJ946uG8AKHTd6CA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
     "css-loader": "^1.0.1",
-    "electron": "^32.3.0",
+    "electron": "^34.1.0",
     "electron-builder": "^26.0.0",
     "file-loader": "^6.2.0",
     "postcss": "^8.4.13",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
     "css-loader": "^1.0.1",
-    "electron": "^34.1.0",
+    "electron": "^34.2.0",
     "electron-builder": "^26.0.7",
     "file-loader": "^6.2.0",
     "postcss": "^8.4.13",

--- a/release-automation/README.md
+++ b/release-automation/README.md
@@ -31,6 +31,9 @@ You must specify which platform to build for:
 --mac-legacy-10.13-10.14
     Create app for macOS 10.13 and 10.14 (less secure than --mac).
 
+--mac-legacy-10.15
+    Create app for macOS 10.15 (less secure than --mac).
+
 --mac-dir
     Generate executables for macOS 10.15 and later but don't package into a complete DMG installer.
     Primarily for debugging.

--- a/release-automation/build.js
+++ b/release-automation/build.js
@@ -18,9 +18,9 @@ const ELECTRON_22_FINAL = '22.3.27';
 const ELECTRON_26_FINAL = '26.6.10';
 
 // Electron 32 is the last version to support macOS 10.15
-// TODO: Electron 32 is still being supported. There will likely be a 32.3.1 etc.
+// TODO: Electron 32 is still being supported. There will likely be a 32.3.2 etc.
 // before support is dropped. Replace this once that happens.
-const ELECTRON_32_FINAL = '32.3.0';
+const ELECTRON_32_FINAL = '32.3.1';
 
 /**
  * @param {string} platformName

--- a/release-automation/build.js
+++ b/release-automation/build.js
@@ -17,6 +17,11 @@ const ELECTRON_22_FINAL = '22.3.27';
 // Electron 26 is the last version to support macOS 10.13, 10.14
 const ELECTRON_26_FINAL = '26.6.10';
 
+// Electron 32 is the last version to support macOS 10.15
+// TODO: Electron 32 is still being supported. There will likely be a 32.3.1 etc.
+// before support is dropped. Replace this once that happens.
+const ELECTRON_32_FINAL = '32.3.0';
+
 /**
  * @param {string} platformName
  * @returns {string} a string that indexes into Arch[...]
@@ -275,6 +280,29 @@ const buildMacLegacy10131014 = () => build({
   }
 });
 
+const buildMacLegacy1015 = () => build({
+  platformName: 'MAC',
+  platformType: 'dmg',
+  manageUpdates: true,
+  legacy: true,
+  extraConfig: {
+    mac: {
+      artifactName: '${productName} Legacy 10.15 Setup ${version}.${ext}'
+    }
+  },
+  prepare: async (archName) => {
+    const electronDist = await downloadElectronArtifact({
+      version: ELECTRON_32_FINAL,
+      platform: 'darwin',
+      artifactName: 'electron',
+      arch: archName
+    });
+    return {
+      electronDist
+    };
+  }
+});
+
 const buildMacDir = () => build({
   platformName: 'MAC',
   platformType: 'dir',
@@ -314,6 +342,7 @@ const run = async () => {
     '--microsoft-store': buildMicrosoftStore,
     '--mac': buildMac,
     '--mac-legacy-10.13-10.14': buildMacLegacy10131014,
+    '--mac-legacy-10.15': buildMacLegacy1015,
     '--mac-dir': buildMacDir,
     '--debian': buildDebian,
     '--tarball': buildTarball,

--- a/release-automation/build.js
+++ b/release-automation/build.js
@@ -11,6 +11,12 @@ const {Platform, Arch} = builder;
 
 const isProduction = process.argv.includes('--production');
 
+// Electron 22 is the last version to support Windows 7, 8, 8.1
+const ELECTRON_22_FINAL = '22.3.27';
+
+// Electron 26 is the last version to support macOS 10.13, 10.14
+const ELECTRON_26_FINAL = '26.6.10';
+
 /**
  * @param {string} platformName
  * @returns {string} a string that indexes into Arch[...]
@@ -190,33 +196,28 @@ const buildWindows = () => build({
   manageUpdates: true
 });
 
-const buildWindowsLegacy = async () => {
-  // This is the last release of Electron 22, which no longer receives updates.
-  const LEGACY_ELECTRON_VERSION = '22.3.27';
-
-  return build({
-    platformName: 'WINDOWS',
-    platformType: 'nsis',
-    manageUpdates: true,
-    legacy: true,
-    extraConfig: {
-      nsis: {
-        artifactName: '${productName} Legacy Setup ${version} ${arch}.${ext}'
-      }
-    },
-    prepare: async (archName) => {
-      const electronDist = await downloadElectronArtifact({
-        version: LEGACY_ELECTRON_VERSION,
-        platform: 'win32',
-        artifactName: 'electron',
-        arch: archName
-      });
-      return {
-        electronDist
-      };
+const buildWindowsLegacy = () => build({
+  platformName: 'WINDOWS',
+  platformType: 'nsis',
+  manageUpdates: true,
+  legacy: true,
+  extraConfig: {
+    nsis: {
+      artifactName: '${productName} Legacy Setup ${version} ${arch}.${ext}'
     }
-  });
-};
+  },
+  prepare: async (archName) => {
+    const electronDist = await downloadElectronArtifact({
+      version: ELECTRON_22_FINAL,
+      platform: 'win32',
+      artifactName: 'electron',
+      arch: archName
+    });
+    return {
+      electronDist
+    };
+  }
+});
 
 const buildWindowsPortable = () => build({
   platformName: 'WINDOWS',
@@ -251,34 +252,28 @@ const buildMac = () => build({
   }
 });
 
-const buildMacLegacy10131014 = () => {
-  // This is the last release of Electron 26
-  // Electron 27 dropped support for macOS 10.13 and 10.14
-  const LEGACY_ELECTRON_VERSION = '26.6.10';
-
-  return build({
-    platformName: 'MAC',
-    platformType: 'dmg',
-    manageUpdates: true,
-    legacy: true,
-    extraConfig: {
-      mac: {
-        artifactName: '${productName} Legacy 10.13 10.14 Setup ${version}.${ext}'
-      }
-    },
-    prepare: async (archName) => {
-      const electronDist = await downloadElectronArtifact({
-        version: LEGACY_ELECTRON_VERSION,
-        platform: 'darwin',
-        artifactName: 'electron',
-        arch: archName
-      });
-      return {
-        electronDist
-      };
+const buildMacLegacy10131014 = () => build({
+  platformName: 'MAC',
+  platformType: 'dmg',
+  manageUpdates: true,
+  legacy: true,
+  extraConfig: {
+    mac: {
+      artifactName: '${productName} Legacy 10.13 10.14 Setup ${version}.${ext}'
     }
-  });
-};
+  },
+  prepare: async (archName) => {
+    const electronDist = await downloadElectronArtifact({
+      version: ELECTRON_26_FINAL,
+      platform: 'darwin',
+      artifactName: 'electron',
+      arch: archName
+    });
+    return {
+      electronDist
+    };
+  }
+});
 
 const buildMacDir = () => build({
   platformName: 'MAC',


### PR DESCRIPTION
33 dropped support for macOS 10.15, so there's now a second legacy build for those people. It's getting a little out of hand.