### PR TITLE
Add resume session desktop setting

### DIFF
--- a/src-main/index.js
+++ b/src-main/index.js
@@ -227,10 +227,21 @@ app.whenReady().then(() => {
     isMigrating = false;
 
     const commandLineOptions = parseCommandLine(process.argv);
-    EditorWindow.openFiles([
+    let filesToOpen = [
       ...filesQueuedToOpen,
       ...commandLineOptions.files
-    ], commandLineOptions.fullscreen, process.cwd());
+    ];
+
+    // If no files specified and resumeSession is enabled, try to open lastOpenedFile
+    if (
+      filesToOpen.length === 0 &&
+      settings.resumeSession &&
+      settings.lastOpenedFile
+    ) {
+      filesToOpen = [settings.lastOpenedFile];
+    }
+
+    EditorWindow.openFiles(filesToOpen, commandLineOptions.fullscreen, process.cwd());
 
     if (AbstractWindow.getAllWindows().length === 0) {
       // No windows were successfully opened. Let's just quit.

--- a/src-main/l10n/en.json
+++ b/src-main/l10n/en.json
@@ -263,6 +263,10 @@
     "string": "Enable spell checker",
     "developer_comment": "Option in desktop settings to disable spell checking"
   },
+  "desktop-settings.resume-session": {
+    "string": "Continue from the last opened file.",
+    "developer_comment": "Desktop settings option to enable session resuming"
+  },
   "desktop-settings.exit-fullscreen-on-escape": {
     "string": "Exit F11 fullscreen mode (not the fullscreen button in the editor) when pressing escape",
     "developer_comment": "Refering to when an entire window is in fullscreen by pressing F11 or the maximize button on macOS, not the fullscreen mode you get by pressing the fullscreen button in the editor."

--- a/src-main/settings.js
+++ b/src-main/settings.js
@@ -164,6 +164,13 @@ class Settings {
     this.data.spellchecker = spellchecker;
   }
 
+  get resumeSession () {
+    return this.data.resumeSession !== false;
+  }
+  set resumeSession (resumeSession) {
+    this.data.resumeSession = resumeSession;
+  }
+
   get exitFullscreenOnEscape () {
     return this.data.exitFullscreenOnEscape !== false;
   }

--- a/src-main/windows/editor.js
+++ b/src-main/windows/editor.js
@@ -644,6 +644,10 @@ class EditorWindow extends ProjectRunningWindow {
         new EditorWindow(parseOpenedFile(file, workingDirectory), fullscreen);
       }
     }
+    if (files && files.length > 0) {
+      settings.lastOpenedFile = files[0];
+      settings.save();
+    }
   }
 
   /**

--- a/src-preload/desktop-settings.js
+++ b/src-preload/desktop-settings.js
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('DesktopSettingsPreload', {
   setBackgroundThrottling: (backgroundThrottling) => ipcRenderer.invoke('set-background-throttling', backgroundThrottling),
   setBypassCORS: (bypassCORS) => ipcRenderer.invoke('set-bypass-cors', bypassCORS),
   setSpellchecker: (spellchecker) => ipcRenderer.invoke('set-spellchecker', spellchecker),
+  setResumeSession: (resumeSession) => ipcRenderer.invoke('set-resume-session', resumeSession),
   setExitFullscreenOnEscape: (exitFullscreenOnEscape) => ipcRenderer.invoke('set-exit-fullscreen-on-escape', exitFullscreenOnEscape),
   setRichPresence: (richPresence) => ipcRenderer.invoke('set-rich-presence', richPresence),
   openUserData: () => ipcRenderer.invoke('open-user-data')

--- a/src-renderer/desktop-settings/desktop-settings.html
+++ b/src-renderer/desktop-settings/desktop-settings.html
@@ -283,6 +283,19 @@
       </script>
 
       <label>
+        <input type="checkbox" class="resume-session-checkbox" autocomplete="off">
+        <span class="resume-session-label"></span>
+      </label>
+      <script>
+        const resumeSession = document.querySelector('.resume-session-checkbox');
+        resumeSession.onchange = () => {
+          DesktopSettingsPreload.setResumeSession(resumeSession.checked);
+        };
+        resumeSession.checked = settings.resumeSession;
+        document.querySelector('.resume-session-label').textContent = strings['desktop-settings.resume-session'];
+      </script>
+
+      <label>
         <input type="checkbox" class="exit-fullscreen-on-escape-checkbox" autocomplete="off">
         <span class="exit-fullscreen-on-escape-label"></span>
       </label>


### PR DESCRIPTION
Add "Continue from the last opened file" setting in Desktop Settings. With the setting enabled, when TurboWarp starts with no other windows open, it starts with the last opened file instead of a blank file.