### PR TITLE
Fix broken focus after cancelling unload on Windows

### DIFF
--- a/src-main/windows/editor.js
+++ b/src-main/windows/editor.js
@@ -251,8 +251,8 @@ class EditorWindow extends ProjectRunningWindow {
     this.window.webContents.on('will-prevent-unload', () => {
       // Using showMessageBoxSync synchronously in the event handler causes broken focus on Windows.
       // See https://github.com/TurboWarp/desktop/issues/1245
-      // To work around that, we'll won't cancel that will-prevent-unload event so the window stays
-      // open. After a very short delay to let focus get fixed, we'll show the dialog and force close
+      // To work around that, we won't cancel that will-prevent-unload event so the window stays
+      // open. After a very short delay to let focus get fixed, we'll show a dialog and force close
       // the window ourselves if the user wants.
 
       setTimeout(() => {


### PR DESCRIPTION
Fix https://github.com/TurboWarp/desktop/issues/1245