### PR TITLE
Fix a typo in `changelog.md` where the script filename was written as `.jsm` instead of `.mjs`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-This document is the authoritative source for TurboWarp's changelogs. Everything else gets generated from this list by `node scripts/generate-changelogs.jsm`.
+This document is the authoritative source for TurboWarp's changelogs. Everything else gets generated from this list by `node scripts/generate-changelogs.mjs`.
 
 Prefix notes with "Windows:", "macOS:", or "Linux:" as needed. Do not use **formatting** or [links](https://desktop.turbowarp.org/).
 


### PR DESCRIPTION
## Changes

Replace:

```
node scripts/generate-changelogs.jsm
```

with:

```
node scripts/generate-changelogs.mjs
```

in the following sentence:

```
This document is the authoritative source for TurboWarp's changelogs. Everything else gets generated from this list by `node scripts/generate-changelogs.mjs`.
```

## Notes

This is a documentation-only fix and does not affect functionality.
